### PR TITLE
Allow library to be initialized in Full DFU mode

### DIFF
--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+#include <nrf_modem.h>
+
 /**
  * @brief Initialize the Modem library.
  *
@@ -18,9 +20,21 @@ extern "C" {
  * initializing the library manually to have control of what
  * the application should do while initialization is ongoing.
  *
+ * Library has two operation modes, normal and DFU.
+ * In normal operation mode, the DFU functionality should is disabled.
+ *
+ * Library can alternatively be initialized in DFU mode, which means that
+ * all shared memory regions are now reserved for DFU operation,
+ * and therefore no other modem functionality can be used.
+ *
+ * To switch between DFU and normal modes, nrf_modem_shutdown() should be
+ * called in between.
+ *
+ * @param[in] mode Library mode.
+ *
  * @return int Zero on success, non-zero otherwise.
  */
-int nrf_modem_lib_init(void);
+int nrf_modem_lib_init(enum nrf_modem_mode_t mode);
 
 /**
  * @brief Makes a thread sleep until next time nrf_modem_lib_init() is called.

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -33,6 +33,28 @@ static struct k_mutex slist_mutex;
 
 static int init_ret;
 
+static const nrf_modem_init_params_t init_params = {
+	.ipc_irq_prio = NRF_MODEM_NETWORK_IRQ_PRIORITY,
+	.shmem.ctrl = {
+		.base = PM_NRF_MODEM_LIB_CTRL_ADDRESS,
+		.size = CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE,
+	},
+	.shmem.tx = {
+		.base = PM_NRF_MODEM_LIB_TX_ADDRESS,
+		.size = CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE,
+	},
+	.shmem.rx = {
+		.base = PM_NRF_MODEM_LIB_RX_ADDRESS,
+		.size = CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE,
+	},
+#if CONFIG_NRF_MODEM_LIB_TRACE_ENABLED
+	.shmem.trace = {
+		.base = PM_NRF_MODEM_LIB_TRACE_ADDRESS,
+		.size = CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE,
+	},
+#endif
+};
+
 static int _nrf_modem_lib_init(const struct device *unused)
 {
 	if (!first_time_init) {
@@ -47,29 +69,7 @@ static int _nrf_modem_lib_init(const struct device *unused)
 	IRQ_CONNECT(NRF_MODEM_NETWORK_IRQ, NRF_MODEM_NETWORK_IRQ_PRIORITY,
 		    nrfx_isr, nrfx_ipc_irq_handler, 0);
 
-	const nrf_modem_init_params_t init_params = {
-		.ipc_irq_prio = NRF_MODEM_NETWORK_IRQ_PRIORITY,
-		.shmem.ctrl = {
-			.base = PM_NRF_MODEM_LIB_CTRL_ADDRESS,
-			.size = CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE,
-		},
-		.shmem.tx = {
-			.base = PM_NRF_MODEM_LIB_TX_ADDRESS,
-			.size = CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE,
-		},
-		.shmem.rx = {
-			.base = PM_NRF_MODEM_LIB_RX_ADDRESS,
-			.size = CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE,
-		},
-#if CONFIG_NRF_MODEM_LIB_TRACE_ENABLED
-		.shmem.trace = {
-			.base = PM_NRF_MODEM_LIB_TRACE_ADDRESS,
-			.size = CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE,
-		},
-#endif
-	};
-
-	init_ret = nrf_modem_init(&init_params);
+	init_ret = nrf_modem_init(&init_params, NORMAL_MODE);
 
 	k_mutex_lock(&slist_mutex, K_FOREVER);
 	if (sys_slist_peek_head(&shutdown_threads) != NULL) {
@@ -112,9 +112,13 @@ void nrf_modem_lib_shutdown_wait(void)
 	k_mutex_unlock(&slist_mutex);
 }
 
-int nrf_modem_lib_init(void)
+int nrf_modem_lib_init(enum nrf_modem_mode_t mode)
 {
-	return _nrf_modem_lib_init(NULL);
+	if (mode == NORMAL_MODE) {
+		return _nrf_modem_lib_init(NULL);
+	} else {
+		return nrf_modem_init(&init_params, FULL_DFU_MODE);
+	}
 }
 
 int nrf_modem_lib_get_init_ret(void)


### PR DESCRIPTION
This FULL_DFU_MODE is where only DFU part of the modem library is
initialized and it uses all of the shared memory region.

Depends on https://github.com/NordicPlayground/libmodem/pull/14