### PR TITLE
lib: nrf_modem: add support for error ECONNREFUSED

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -307,6 +307,9 @@ void nrf_modem_os_errno_set(int err_code)
 	case NRF_ETIMEDOUT:
 		errno = ETIMEDOUT;
 		break;
+	case NRF_ECONNREFUSED:
+		errno = ECONNREFUSED;
+		break;
 	case NRF_ENOBUFS:
 		errno = ENOBUFS;
 		break;


### PR DESCRIPTION
This commit adds support for error ECONNREFUSED.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>