### PR TITLE
Add support for NRF_AF_UNSPEC address type

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -354,7 +354,7 @@ static int z_to_nrf_family(sa_family_t z_family)
 	case AF_PACKET:
 		return NRF_AF_PACKET;
 	case AF_UNSPEC:
-	/* No NRF_AF_UNSPEC defined. */
+		return NRF_AF_UNSPEC;
 	default:
 		return -EAFNOSUPPORT;
 	}
@@ -373,6 +373,8 @@ static int nrf_to_z_family(nrf_socket_family_t nrf_family)
 		return AF_LOCAL;
 	case NRF_AF_PACKET:
 		return AF_PACKET;
+	case NRF_AF_UNSPEC:
+		return AF_UNSPEC;
 	default:
 		return -EAFNOSUPPORT;
 	}


### PR DESCRIPTION
Modem library has now a support for NRF_AF_UNSPEC address type
for DNS queries.

Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>