### PR TITLE
lib: nrf_modem: add support for TCP server timeout

### DIFF
--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -212,6 +212,9 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		case SO_IPV6_ECHO_REPLY:
 			*nrf_out_optname = NRF_SO_SILENCE_IPV6_ECHO_REPLY;
 			break;
+		case SO_TCP_SRV_SESSTIMEO:
+			*nrf_out_optname = NRF_SO_TCP_SRV_SESSTIMEO;
+			break;
 		default:
 			retval = -1;
 			break;


### PR DESCRIPTION
This commit adds support in the offloading layer for the new
TCP server timeout socket option.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>

sdk-zephyr related PR: https://github.com/nrfconnect/sdk-zephyr/pull/527