### PR TITLE
libmodem: align API return values os

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -194,7 +194,7 @@ int32_t nrf_modem_os_timedwait(uint32_t context, int32_t *timeout)
 
 	if (*timeout == 0) {
 		k_yield();
-		return NRF_ETIMEDOUT;
+		return -NRF_ETIMEDOUT;
 	}
 
 	if (*timeout < 0) {
@@ -220,7 +220,7 @@ int32_t nrf_modem_os_timedwait(uint32_t context, int32_t *timeout)
 	*timeout = remaining > 0 ? remaining : 0;
 
 	if (*timeout == 0) {
-		return NRF_ETIMEDOUT;
+		return -NRF_ETIMEDOUT;
 	}
 
 	return 0;


### PR DESCRIPTION
Update functions in nrf_modem_os.c to return negative NRF_ERRNOs on error.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>