### PR TITLE
lib: nrf_modem: align return values and add logging

### DIFF
--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -43,7 +43,8 @@ extern "C" {
  *
  * @param[in] mode Library mode.
  *
- * @return int Zero on success, non-zero otherwise.
+ * @retval Zero on success.
+ * @retval A negative errno on failiure.
  */
 int nrf_modem_lib_init(enum nrf_modem_mode_t mode);
 
@@ -62,14 +63,15 @@ void nrf_modem_lib_shutdown_wait(void);
  * nrf_modem_lib_init. This can be used to check the state of a modem
  * firmware exchange when the Modem library was initialized at boot-time.
  *
- * @return int The last return value of nrf_modem_lib_init.
+ * @retval The last return value of @ref nrf_modem_lib_init().
  */
 int nrf_modem_lib_get_init_ret(void);
 
 /**
  * @brief Shutdown the Modem library, releasing its resources.
  *
- * @return int Zero on success, non-zero otherwise.
+ * @retval Zero on success.
+ * @retval A negative value errno on failiure.
  */
 int nrf_modem_lib_shutdown(void);
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -120,7 +120,8 @@ int nrf_modem_lib_init(enum nrf_modem_mode_t mode)
 	if (mode == NORMAL_MODE) {
 		return _nrf_modem_lib_init(NULL);
 	} else {
-		return nrf_modem_init(&init_params, FULL_DFU_MODE);
+		init_ret = nrf_modem_init(&init_params, FULL_DFU_MODE);
+		return init_ret;
 	}
 }
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -131,12 +131,25 @@ int nrf_modem_lib_get_init_ret(void)
 
 int nrf_modem_lib_shutdown(void)
 {
-#ifdef CONFIG_LTE_LINK_CONTROL
-	lte_lc_deinit();
-#endif
-	nrf_modem_shutdown();
+	int err = 0;
+	int err_temp;
 
-	return 0;
+#ifdef CONFIG_LTE_LINK_CONTROL
+	err = lte_lc_deinit();
+	if (err) {
+		LOG_ERR("LTE LC deinit failed, error: %d", err);
+	}
+
+#endif /* CONFIG_LTE_LINK_CONTROL */
+
+	/* Do not overwrite lte_lc_deinit error */
+	err_temp = nrf_modem_shutdown();
+	if (err_temp) {
+		LOG_ERR("Modem shutdown failed, error: %d", err);
+		err = (err == 0 ? err_temp : err);
+	}
+
+	return err;
 }
 
 #if defined(CONFIG_NRF_MODEM_LIB_SYS_INIT)

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -12,6 +12,7 @@
 #include <nrf_modem.h>
 #include <nrf_modem_platform.h>
 #include <pm_config.h>
+#include <logging/log.h>
 
 #ifdef CONFIG_LTE_LINK_CONTROL
 #include <modem/lte_lc.h>
@@ -21,6 +22,8 @@
 #error  nrf_modem_lib must be run as non-secure firmware.\
 	Are you building for the correct board ?
 #endif
+
+LOG_MODULE_REGISTER(nrf_modem_lib, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
 
 struct shutdown_thread {
 	sys_snode_t node;

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -30,7 +30,7 @@
 
 #define THREAD_MONITOR_ENTRIES 10
 
-LOG_MODULE_REGISTER(nrf_modem_lib, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
+LOG_MODULE_DECLARE(nrf_modem_lib);
 
 struct mem_diagnostic_info {
 	uint32_t failed_allocs;


### PR DESCRIPTION
Update init and shutdown return value documentation in nrf_modem header.
Add logging to nrf_modem_lib using same level as nrf_modem_os.
Update nrf_modem_lib_shutdown to return error if present.
Update init_ret on calling nrf_modem_init() with full_dfu_mode.