### PR TITLE
lib: modem_os: Return negative nrf_errno in nrf_modem_os_sem_take

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -408,7 +408,7 @@ int nrf_modem_os_sem_take(void *sem, int timeout)
 
 	err = k_sem_take((struct k_sem *)sem, timeout == -1 ? K_FOREVER : K_MSEC(timeout));
 	if (err == -EAGAIN) {
-		return NRF_ETIMEDOUT;
+		return -NRF_ETIMEDOUT;
 	}
 
 	return 0;


### PR DESCRIPTION
Align nrf_modem_os_sem_take to return negative errno on error.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>