### PR TITLE
nrf_modem_lib: removal of deprecated socket dfu

### DIFF
--- a/doc/nrf/libraries/dfu/dfu_target.rst
+++ b/doc/nrf/libraries/dfu/dfu_target.rst
@@ -55,11 +55,11 @@ On the next reboot, the device will run the new firmware.
 Modem delta upgrades
 ====================
 
-This type of firmware upgrade opens a socket into the modem and passes the data given to the :c:func:`dfu_target_write` function through the socket.
-The modem stores the data in the memory location for firmware patches.
+This type of firmware upgrade is used for delta upgrades to the modem firmware (see: :ref:`nrf_modem_delta_dfu`).
+The modem stores the data in the memory location reserved for firmware patches.
 If there is already a firmware patch stored in the modem, the library requests the modem to delete the old firmware patch, to make space for the new patch.
 
-When the complete transfer is done, call the :c:func:`dfu_target_done` function to request the modem to apply the patch, and to close the socket.
+When the transfer is completed, call the :c:func:`dfu_target_done` function to request the modem to apply the patch.
 On the next reboot, the modem will try to apply the patch.
 
 .. _lib_dfu_target_full_modem_update:

--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -476,6 +476,10 @@ Libraries for networking
 
   * Updated to v0.21.0. See the :ref:`liblwm2m_carrier_changelog` for detailed information.
 
+* :ref:`lib_dfu_target` library:
+
+  * Updated the implementation of modem delta upgrades in the DFU target library to use the new socketless interface provided by the :ref:`nrf_modem`.
+
 Libraries for NFC
 -----------------
 

--- a/lib/nrf_modem_lib/nrf91_sockets.c
+++ b/lib/nrf_modem_lib/nrf91_sockets.c
@@ -143,9 +143,6 @@ static int z_to_nrf_level(int z_in_level, int *nrf_out_level)
 	case SOL_SOCKET:
 		*nrf_out_level = NRF_SOL_SOCKET;
 		break;
-	case SOL_DFU:
-		*nrf_out_level = NRF_SOL_DFU;
-		break;
 	default:
 		retval = -1;
 		break;
@@ -245,38 +242,6 @@ static int z_to_nrf_optname(int z_in_level, int z_in_optname,
 		}
 		break;
 
-	case SOL_DFU:
-		switch (z_in_optname) {
-		case SO_DFU_FW_VERSION:
-			*nrf_out_optname = NRF_SO_DFU_FW_VERSION;
-			break;
-		case SO_DFU_RESOURCES:
-			*nrf_out_optname = NRF_SO_DFU_RESOURCES;
-			break;
-		case SO_DFU_TIMEO:
-			*nrf_out_optname = NRF_SO_DFU_TIMEO;
-			break;
-		case SO_DFU_APPLY:
-			*nrf_out_optname = NRF_SO_DFU_APPLY;
-			break;
-		case SO_DFU_REVERT:
-			*nrf_out_optname = NRF_SO_DFU_REVERT;
-			break;
-		case SO_DFU_BACKUP_DELETE:
-			*nrf_out_optname = NRF_SO_DFU_BACKUP_DELETE;
-			break;
-		case SO_DFU_OFFSET:
-			*nrf_out_optname = NRF_SO_DFU_OFFSET;
-			break;
-		case SO_DFU_ERROR:
-			*nrf_out_optname = NRF_SO_DFU_ERROR;
-			break;
-		default:
-			retval = -1;
-			break;
-		}
-		break;
-
 	default:
 		retval = -1;
 		break;
@@ -359,8 +324,6 @@ static int z_to_nrf_family(sa_family_t z_family)
 		return NRF_AF_INET6;
 	case AF_LTE:
 		return NRF_AF_LTE;
-	case AF_LOCAL:
-		return NRF_AF_LOCAL;
 	case AF_PACKET:
 		return NRF_AF_PACKET;
 	case AF_UNSPEC:
@@ -379,8 +342,6 @@ static int nrf_to_z_family(nrf_socket_family_t nrf_family)
 		return AF_INET6;
 	case NRF_AF_LTE:
 		return AF_LTE;
-	case NRF_AF_LOCAL:
-		return AF_LOCAL;
 	case NRF_AF_PACKET:
 		return AF_PACKET;
 	case NRF_AF_UNSPEC:
@@ -399,8 +360,6 @@ static int nrf_to_z_protocol(int proto)
 		return IPPROTO_UDP;
 	case NRF_SPROTO_TLS1v2:
 		return IPPROTO_TLS_1_2;
-	case NRF_PROTO_DFU:
-		return NPROTO_DFU;
 	case NRF_PROTO_AT:
 		return NPROTO_AT;
 	case 0:
@@ -438,8 +397,6 @@ static int z_to_nrf_protocol(int proto)
 		return NRF_SPROTO_TLS1v2;
 	case NPROTO_AT:
 		return NRF_PROTO_AT;
-	case NPROTO_DFU:
-		return NRF_PROTO_DFU;
 	case PROTO_WILDCARD:
 		return 0;
 	/*

--- a/west.yml
+++ b/west.yml
@@ -35,6 +35,9 @@ manifest:
       url-base: https://github.com/PelionIoT
     - name: memfault
       url-base: https://github.com/memfault
+    - name: lemrey
+      url-base: https://github.com/lemrey
+
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -54,7 +57,8 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: eb0a5b6574d7cd1942ffce0d7424528565de1cb2
+      remote: lemrey
+      revision: e37c4108bd3a04c300228f5b17c6d1c8943f1a53
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Remove deprecated API translations for socket dfu.

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>

_Commit: 9121b9c2e6272297e16c79a61c4b73a5ee1f3eb5 to be removed after [nrfconnect/sdk-nrf#6055](https://github.com/nrfconnect/sdk-nrf/pull/6055) is merged and included into lemrey/sdk-nrf_