### PR TITLE
Nits: Release v1.4.0

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -72,7 +72,7 @@ endif # NRF_MODEM_LIB_TRACE_ENABLED
 config NRF_MODEM_LIB_AT_CMD_FILTER
 	bool "Enable AT command filters"
 	help
-	  When  enabled, filtered AT commands are redirected to an application-provided
+	  When enabled, filtered AT commands are redirected to an application-provided
 	  implementation.
 
 config NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS

--- a/lib/nrf_modem_lib/nrf_modem_at_cmd_filter.c
+++ b/lib/nrf_modem_lib/nrf_modem_at_cmd_filter.c
@@ -265,7 +265,6 @@ static int at_cmd_filter_cmgw(char *buf, size_t len, const char *at_cmd)
 			/* Make AT response. */
 			return response_buffer_fill(buf, len,
 					"+CMGW: %d\r\nOK\r\n", i+1);
-			return 0;
 		}
 	}
 

--- a/subsys/dfu/fmfu_fdev/src/fmfu_fdev.c
+++ b/subsys/dfu/fmfu_fdev/src/fmfu_fdev.c
@@ -158,7 +158,7 @@ static int load_segments(const struct device *fdev, uint8_t *meta_buf,
 			err = nrf_modem_full_dfu_verify(wrapper_len,
 							(void *)meta_buf);
 			if (err != 0) {
-				LOG_ERR("nrf_fmfu_verify_signature failed, err: %d",err);
+				LOG_ERR("nrf_fmfu_verify_signature failed, err: %d", err);
 				return err;
 			}
 #else

--- a/subsys/mgmt/fmfu/src/fmfu_mgmt.c
+++ b/subsys/mgmt/fmfu/src/fmfu_mgmt.c
@@ -159,8 +159,7 @@ static int fmfu_firmware_upload(struct mgmt_ctxt *ctx)
 							 packet.data_len,
 							 packet.data);
 			if (rc != 0) {
-				LOG_ERR("Error in writing data,"
-					" err: %d", rc);
+				LOG_ERR("Error in writing data, err: %d", rc);
 				return MGMT_ERR_EBADSTATE;
 			}
 		}


### PR DESCRIPTION
Nitpicking for the libmodem release v1.4.0. 
Solving compliance issue with missing space after comma. 

@lemrey Don't know if you want to do it like this or rebase the original commits?