### PR TITLE
lib: nrf_modem_lib: os: Use exported number of semaphores from modem lib

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -239,8 +239,7 @@ bool nrf_modem_os_is_in_isr(void)
 	return k_is_in_isr();
 }
 
-#define NRF_MODEM_OS_SEM_MAX 3
-static struct k_sem nrf_modem_os_sems[NRF_MODEM_OS_SEM_MAX];
+static struct k_sem nrf_modem_os_sems[NRF_MODEM_OS_NUM_SEM_REQUIRED];
 
 int nrf_modem_os_sem_init(void **sem,
 	unsigned int initial_count, unsigned int limit)
@@ -251,7 +250,7 @@ int nrf_modem_os_sem_init(void **sem,
 		goto recycle;
 	}
 
-	__ASSERT(used < NRF_MODEM_OS_SEM_MAX,
+	__ASSERT(used < NRF_MODEM_OS_NUM_SEM_REQUIRED,
 		 "Not enough semaphores in glue layer");
 
 	*sem = &nrf_modem_os_sems[used++];


### PR DESCRIPTION
[NCSDK-12962](https://projecttools.nordicsemi.no/jira/browse/NCSDK-12962)
Use number of semaphores defined in nrf_modem_os.h to avoid mismatch
between library requirements and glue configuration.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>