### PR TITLE
lib: nrf_modem: set modem irq priorities on application side

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -189,6 +189,35 @@ config NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS
 
 endif
 
+menu "Interrupt priorities"
+
+DT_IPC := $(dt_nodelabel_path,ipc)
+DT_EGU1 := $(dt_nodelabel_path,egu1)
+
+config NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+	bool "Override IPC IRQ in Device Tree"
+	default n
+	help
+	Override the IPC IRQ priority set in device tree
+
+config NRF_MODEM_IPC_IRQ_PRIO
+	int "IPC IRQ priority" if NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1) if !NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+	default 2 if NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+
+config NRF_MODEM_APPLICATION_IRQ_PRIO_DTS_OVERRIDE
+	bool "Override EGU1 IRQ in Device Tree"
+	default y
+	help
+	Override the EGU1 IRQ priority set in device tree
+
+config NRF_MODEM_APPLICATION_IRQ_PRIO
+	int "EGU1 IRQ priority" if NRF_MODEM_APPLICATION_IRQ_PRIO_DTS_OVERRIDE
+	default $(dt_node_array_prop_int,$(DT_EGU1),interrupts,1) if !NRF_MODEM_APPLICATION_IRQ_PRIO_DTS_OVERRIDE
+	default 6 if NRF_MODEM_APPLICATION_IRQ_PRIO_DTS_OVERRIDE
+
+endmenu
+
 module = NRF_MODEM_LIB
 module-str = Modem library
 source "subsys/logging/Kconfig.template.log_config"

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -7,7 +7,6 @@
 #include <nrfx_ipc.h>
 #include <nrf_modem.h>
 #include <nrf_modem_at.h>
-#include <nrf_modem_platform.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
@@ -24,6 +23,10 @@
 
 LOG_MODULE_DECLARE(nrf_modem, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
 
+/* Interrupt used for communication with the network layer. */
+#define NRF_MODEM_IPC_IRQ DT_IRQ_BY_IDX(DT_NODELABEL(ipc), 0, irq)
+BUILD_ASSERT(IPC_IRQn == NRF_MODEM_IPC_IRQ, "NRF_MODEM_IPC_IRQ mismatch");
+
 struct shutdown_thread {
 	sys_snode_t node;
 	struct k_sem sem;
@@ -37,7 +40,7 @@ static int init_ret;
 static enum nrf_modem_mode init_mode;
 
 static const struct nrf_modem_init_params init_params = {
-	.ipc_irq_prio = NRF_MODEM_NETWORK_IRQ_PRIORITY,
+	.ipc_irq_prio = CONFIG_NRF_MODEM_IPC_IRQ_PRIO,
 	.shmem.ctrl = {
 		.base = PM_NRF_MODEM_LIB_CTRL_ADDRESS,
 		.size = CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE,
@@ -115,7 +118,7 @@ static int _nrf_modem_lib_init(const struct device *unused)
 	/* Setup the network IRQ used by the Modem library.
 	 * Note: No call to irq_enable() here, that is done through nrf_modem_init().
 	 */
-	IRQ_CONNECT(NRF_MODEM_NETWORK_IRQ, NRF_MODEM_NETWORK_IRQ_PRIORITY,
+	IRQ_CONNECT(NRF_MODEM_IPC_IRQ, CONFIG_NRF_MODEM_IPC_IRQ_PRIO,
 		    nrfx_isr, nrfx_ipc_irq_handler, 0);
 
 	init_ret = nrf_modem_init(&init_params, NORMAL_MODE);

--- a/west.yml
+++ b/west.yml
@@ -31,6 +31,8 @@ manifest:
       url-base: https://github.com/NordicSemiconductor
     - name: memfault
       url-base: https://github.com/memfault
+    - name: eivindj-nordic
+      url-base: https://github.com/eivindj-nordic
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -50,7 +52,8 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 3db330717c1ca3ec4fb133400bf3eb7156aa6cbd
+      remote: eivindj-nordic
+      revision: 8167_review_platform_h_file
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Add os_config header to allow changing the irq priorities in the
application. Get modem IRQ priorities from device tree when using
zephyr.

[sdk-zephyr integration PR-3](https://github.com/lemrey/sdk-zephyr/pull/3)

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>