### PR TITLE
lib: nrf_modem: add FW version and UUID log

### DIFF
--- a/lib/nrf_modem_lib/Kconfig
+++ b/lib/nrf_modem_lib/Kconfig
@@ -172,6 +172,10 @@ config NRF_MODEM_LIB_SHMEM_TX_DUMP_PERIOD_MS
 	int "Period (millisec)"
 	default 20000
 
+config NRF_MODEM_LIB_LOG_FW_VERSION_UUID
+    depends on LOG
+    bool "Log FW version and UUID during initialization"
+
 endmenu
 
 module = NRF_MODEM_LIB


### PR DESCRIPTION
This commit adds logging for both FW version
and UUID at the end of the library initialization
step.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>