### PR TITLE
lib: nrf_modem: Implement trace irq disable and enable functions

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -293,6 +293,16 @@ void nrf_modem_os_trace_irq_clear(void)
 	NVIC_ClearPendingIRQ(TRACE_IRQ);
 }
 
+void nrf_modem_os_trace_irq_disable(void)
+{
+	irq_disable(TRACE_IRQ);
+}
+
+void nrf_modem_os_trace_irq_enable(void)
+{
+	irq_enable(TRACE_IRQ);
+}
+
 ISR_DIRECT_DECLARE(rpc_proxy_irq_handler)
 {
 	atomic_inc(&rpc_event_cnt);


### PR DESCRIPTION
Implement nrf_modem_os_trace_irq_disable and
nrf_modem_os_trace_irq_disable functions in the glue layer.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>