### PR TITLE
nrf: remove usage of `nrf_modem_limits.h` macros

### DIFF
--- a/applications/serial_lte_modem/src/slm_at_host.c
+++ b/applications/serial_lte_modem/src/slm_at_host.c
@@ -28,8 +28,7 @@ LOG_MODULE_REGISTER(slm_at_host, CONFIG_SLM_LOG_LEVEL);
 #define SLM_SYNC_STR	"Ready\r\n"
 
 /** The maximum allowed length of an AT command passed through the SLM
- *  The space is allocated statically. This limit is in turn limited by
- *  Modem library's NRF_MODEM_AT_MAX_CMD_SIZE */
+ *  The space is allocated statically. */
 #define AT_MAX_CMD_LEN          4096
 
 #define UART_RX_BUF_NUM         2

--- a/ext/curl/lib/url.h
+++ b/ext/curl/lib/url.h
@@ -44,7 +44,7 @@
 #include <nrf_modem_limits.h>
 /* In embedded this needs to be a lot of smaller */
 #define UPLOADBUFFER_DEFAULT (708)
-#define UPLOADBUFFER_MAX (NRF_MODEM_IP_MAX_MESSAGE_SIZE)
+#define UPLOADBUFFER_MAX (4096)
 #define UPLOADBUFFER_MIN (CURL_MAX_WRITE_SIZE)
 #else
 #define UPLOADBUFFER_DEFAULT 65536

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -80,7 +80,6 @@ config AT_HOST_CMD_MAX_LEN
 	help
 		The maximum allowed length of an AT command passed through the
 		AT host. The space is allocated statically.
-		This limit is in turn limited by Modem library's NRF_MODEM_AT_MAX_CMD_SIZE.
 	range 0 4096
 	default 4096
 


### PR DESCRIPTION
they're gone