### PR TITLE
lib: modem: Remove application IRQ

### DIFF
--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -189,6 +189,22 @@ config NRF_MODEM_LIB_MEM_DIAG_DUMP_PERIOD_MS
 
 endif
 
+menu "Interrupt priorities"
+
+DT_IPC := $(dt_nodelabel_path,ipc)
+
+config NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+	bool "Override IPC IRQ in Device Tree"
+	default n
+	help
+	Override the IPC IRQ priority set in device tree
+
+config NRF_MODEM_IPC_IRQ_PRIO
+	int "IPC IRQ priority" if NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+	default $(dt_node_array_prop_int,$(DT_IPC),interrupts,1) if !NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+	default 2 if NRF_MODEM_IPC_IRQ_PRIO_DTS_OVERRIDE
+endmenu
+
 module = NRF_MODEM_LIB
 module-str = Modem library
 source "subsys/logging/Kconfig.template.log_config"

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -7,7 +7,6 @@
 #include <nrfx_ipc.h>
 #include <nrf_modem.h>
 #include <nrf_modem_at.h>
-#include <nrf_modem_platform.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
@@ -24,6 +23,10 @@
 
 LOG_MODULE_DECLARE(nrf_modem, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
 
+/* Interrupt used for communication with the network layer. */
+#define NRF_MODEM_IPC_IRQ DT_IRQ_BY_IDX(DT_NODELABEL(ipc), 0, irq)
+BUILD_ASSERT(IPC_IRQn == NRF_MODEM_IPC_IRQ, "NRF_MODEM_IPC_IRQ mismatch");
+
 struct shutdown_thread {
 	sys_snode_t node;
 	struct k_sem sem;
@@ -37,7 +40,7 @@ static int init_ret;
 static enum nrf_modem_mode init_mode;
 
 static const struct nrf_modem_init_params init_params = {
-	.ipc_irq_prio = NRF_MODEM_NETWORK_IRQ_PRIORITY,
+	.ipc_irq_prio = CONFIG_NRF_MODEM_IPC_IRQ_PRIO,
 	.shmem.ctrl = {
 		.base = PM_NRF_MODEM_LIB_CTRL_ADDRESS,
 		.size = CONFIG_NRF_MODEM_LIB_SHMEM_CTRL_SIZE,
@@ -115,7 +118,7 @@ static int _nrf_modem_lib_init(const struct device *unused)
 	/* Setup the network IRQ used by the Modem library.
 	 * Note: No call to irq_enable() here, that is done through nrf_modem_init().
 	 */
-	IRQ_CONNECT(NRF_MODEM_NETWORK_IRQ, NRF_MODEM_NETWORK_IRQ_PRIORITY,
+	IRQ_CONNECT(NRF_MODEM_IPC_IRQ, CONFIG_NRF_MODEM_IPC_IRQ_PRIO,
 		    nrfx_isr, nrfx_ipc_irq_handler, 0);
 
 	init_ret = nrf_modem_init(&init_params, NORMAL_MODE);

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -274,15 +274,6 @@ unsigned int nrf_modem_os_sem_count_get(void *sem)
 	return k_sem_count_get(sem);
 }
 
-void nrf_modem_os_application_irq_set(void)
-{
-	NVIC_SetPendingIRQ(APPLICATION_IRQ);
-}
-
-void nrf_modem_os_application_irq_clear(void)
-{
-	NVIC_ClearPendingIRQ(APPLICATION_IRQ);
-}
 
 void nrf_modem_os_event_notify(void)
 {
@@ -294,24 +285,6 @@ void nrf_modem_os_event_notify(void)
 	SYS_SLIST_FOR_EACH_CONTAINER(&sleeping_threads, thread, node) {
 		k_sem_give(&thread->sem);
 	}
-}
-
-ISR_DIRECT_DECLARE(rpc_proxy_irq_handler)
-{
-	nrf_modem_application_irq_handler();
-
-	nrf_modem_os_event_notify();
-
-	ISR_DIRECT_PM(); /* PM done after servicing interrupt for best latency
-			  */
-	return 1; /* We should check if scheduling decision should be made */
-}
-
-void read_task_create(void)
-{
-	IRQ_DIRECT_CONNECT(APPLICATION_IRQ, APPLICATION_IRQ_PRIORITY,
-			   rpc_proxy_irq_handler, UNUSED_FLAGS);
-	irq_enable(APPLICATION_IRQ);
 }
 
 void *nrf_modem_os_alloc(size_t bytes)
@@ -445,9 +418,6 @@ static int on_init(const struct device *dev)
  */
 void nrf_modem_os_init(void)
 {
-	read_task_create();
-
-	/* Initialize heaps */
 	k_heap_init(&nrf_modem_lib_heap, library_heap_buf, sizeof(library_heap_buf));
 	k_heap_init(&nrf_modem_lib_shmem_heap, (void *)PM_NRF_MODEM_LIB_TX_ADDRESS,
 		    CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE);

--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -9,7 +9,6 @@
 #include <zephyr/kernel.h>
 #include <nrf_modem.h>
 #include <nrf_modem_os.h>
-#include <nrf_modem_platform.h>
 #include <nrf.h>
 #include <nrfx_ipc.h>
 #include <nrf_errno.h>
@@ -18,13 +17,6 @@
 #include <zephyr/logging/log.h>
 
 #define UNUSED_FLAGS 0
-
-/* Handle communication with application from IRQ contexts
- * with the lowest available priority.
- */
-#define APPLICATION_IRQ EGU1_IRQn
-#define APPLICATION_IRQ_PRIORITY IRQ_PRIO_LOWEST
-
 #define THREAD_MONITOR_ENTRIES 10
 
 LOG_MODULE_REGISTER(nrf_modem, CONFIG_NRF_MODEM_LIB_LOG_LEVEL);
@@ -273,7 +265,6 @@ unsigned int nrf_modem_os_sem_count_get(void *sem)
 {
 	return k_sem_count_get(sem);
 }
-
 
 void nrf_modem_os_event_notify(void)
 {


### PR DESCRIPTION
Remove application IRQ (EGU1) from modem library.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>