### PR TITLE
lib: nrf_modem_lib: change os_sem_take return value to -NRF_EAGAIN

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_os.c
+++ b/lib/nrf_modem_lib/nrf_modem_os.c
@@ -271,7 +271,7 @@ int nrf_modem_os_sem_take(void *sem, int timeout)
 
 	err = k_sem_take((struct k_sem *)sem, timeout == -1 ? K_FOREVER : K_MSEC(timeout));
 	if (err) {
-		return NRF_ETIMEDOUT;
+		return -NRF_EAGAIN;
 	}
 
 	return 0;


### PR DESCRIPTION
Change nrf_modem_os_sem_take return value to -NRF_EAGAIN.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>