### PR TITLE
lib: nrf_modem: add timeout to trace_get

### DIFF
--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -84,7 +84,7 @@ trace_reset:
 	k_sem_take(&trace_sem, K_FOREVER);
 
 	while (true) {
-		err = nrf_modem_trace_get(&frags, &n_frags);
+		err = nrf_modem_trace_get(&frags, &n_frags, NRF_MODEM_OS_FOREVER);
 		switch (err) {
 		case -NRF_ESHUTDOWN:
 			LOG_INF("Modem was turned off, no more traces");

--- a/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
+++ b/tests/lib/nrf_modem_lib/nrf_modem_lib_trace/src/main.c
@@ -143,7 +143,7 @@ int32_t nrf_modem_os_timedwait_stub(uint32_t context, int32_t *timeout, int cmoc
 	return 0;
 }
 
-int nrf_modem_trace_get_stub(struct nrf_modem_trace_data **frags, size_t *n_frags,
+int nrf_modem_trace_get_stub(struct nrf_modem_trace_data** frags, size_t* n_frags, int timeout,
 			     int cmock_num_calls)
 {
 	/* `cmock_num_calls` is reset to 0 at the beginning of each independent test execution. */


### PR DESCRIPTION
Update nrf_modem_trace_get call to have the timeout in the input
parameters.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>