### PR TITLE
lib: nrf_modem: trace: add backend bitrate logging

### DIFF
--- a/include/modem/nrf_modem_lib_trace.h
+++ b/include/modem/nrf_modem_lib_trace.h
@@ -51,6 +51,16 @@ int nrf_modem_lib_trace_processing_done_wait(k_timeout_t timeout);
  */
 int nrf_modem_lib_trace_level_set(enum nrf_modem_lib_trace_level trace_level);
 
+/** @brief Get min, max and avg bitrate values of trace backend.
+ *
+ * @param[out] min_val Minimum bitrate
+ * @param[out] max_val Maximum bitrate
+ * @param[out] avg_val Average bitrate
+ *
+ * @return Zero on success, non-zero otherwise.
+ */
+int nrf_modem_lib_trace_backend_bitrate_get(double *min_val, double *max_val, double *avg_val);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/lib/nrf_modem_lib/Kconfig.modemlib
+++ b/lib/nrf_modem_lib/Kconfig.modemlib
@@ -31,6 +31,7 @@ config NRF_MODEM_LIB_TRACE_ENABLED
 	  Trace data is output on the chosen trace backend.
 
 config NRF_MODEM_LIB_TRACE
+	select FPU
 	bool "Enable proprietary traces" if !NRF_MODEM_LIB_TRACE_ENABLED
 	default y if NRF_MODEM_LIB_TRACE_ENABLED
 	help
@@ -76,6 +77,19 @@ config NRF_MODEM_LIB_TRACE_THREAD_PRIO
 	int "Priority of the trace processing thread"
 	depends on NRF_MODEM_LIB_TRACE_THREAD_PRIO_OVERRIDE
 	default 0
+
+config NRF_MODEM_LIB_TRACE_LOG_BITRATE
+	depends on LOG
+	bool "Log trace backend bitrate"
+	select NEWLIB_LIBC_FLOAT_PRINTF
+
+if NRF_MODEM_LIB_TRACE_LOG_BITRATE
+
+config NRF_MODEM_LIB_TRACE_LOG_BITRATE_PERIOD_MSEC
+	int "Bitrate log interval (millisec)"
+	default 5000
+
+endif # NRF_MODEM_LIB_TRACE_LOG_BITRATE
 
 # Add trace backends
 rsource "trace_backends/Kconfig"


### PR DESCRIPTION
This commit adds logging for backend bitrate. Useful for measuring performance of trace backends.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>