### PR TITLE
lib: nrf_modem: split bootloader and normal library initialization

### DIFF
--- a/doc/nrf/libraries/dfu/fmfu_fdev.rst
+++ b/doc/nrf/libraries/dfu/fmfu_fdev.rst
@@ -17,7 +17,7 @@ For more information, see :ref:`lib_dfu_target_full_modem_update`.
 
 The serialized modem firmware contains the hash of the firmware and a signature.
 These fields are used to pre-validate the modem firmware before it is programmed to the modem, ensuring that the data about to be written corresponds to the data that have been signed.
-Once the modem firmware is pre-validated, it is written to the modem using the :file:`nrf_modem_full_dfu.h` API.
+Once the modem firmware is pre-validated, it is written to the modem using the :file:`nrf_modem_bootloader.h` API.
 
 .. _lib_fmfu_fdev_serialization:
 

--- a/doc/nrf/libraries/networking/nrf_cloud.rst
+++ b/doc/nrf/libraries/networking/nrf_cloud.rst
@@ -139,7 +139,7 @@ Following are the supported FOTA types:
 
 * ``"APP"`` - updates the application.
 * ``"BOOT"`` - updates the :ref:`upgradable_bootloader`.
-* ``"MDM_FULL"`` - :ref:`Full modem FOTA <full_dfu>` updates the entire modem firmware image. Full modem updates require |external_flash_size| of available space. For the nRF9160, a full modem firmware image is approximately 2 MB. Consider the power and network costs before deploying full modem FOTA updates.
+* ``"MDM_FULL"`` - :ref:`Full modem FOTA <nrf_modem_bootloader>` updates the entire modem firmware image. Full modem updates require |external_flash_size| of available space. For the nRF9160, a full modem firmware image is approximately 2 MB. Consider the power and network costs before deploying full modem FOTA updates.
 * ``"MODEM"`` - :ref:`Delta modem FOTA <nrf_modem_delta_dfu>` applies incremental changes between specific versions of the modem firmware. Delta modem updates are much smaller in size and do not require external memory.
 
 For example, a device that supports all the FOTA types writes the following data into the device shadow:

--- a/doc/nrf/releases/release-notes-1.7.0.rst
+++ b/doc/nrf/releases/release-notes-1.7.0.rst
@@ -599,7 +599,7 @@ nrfxlib
 * :ref:`nrf_modem` section pages:
 
   * :ref:`nrfxlib:nrf_modem_api` - Updated with new API sections.
-  * :ref:`full_dfu` - Updated with major changes.
+  * :ref:`nrfxlib:nrf_modem_bootloader` - Updated with major changes.
   * Renamed the "AT commands" page to ``AT socket``.
   * :ref:`nrfxlib:nrf_modem_at` - Page added.
   * :ref:`nrfxlib:nrf_modem_delta_dfu` - Page added.

--- a/doc/nrf/releases/release-notes-1.8.0.rst
+++ b/doc/nrf/releases/release-notes-1.8.0.rst
@@ -719,7 +719,7 @@ Modem library
     See the :ref:`nrfxlib:nrf_modem_changelog` for detailed information.
   * nrf_errno values have been aligned with the errno values of newlibc C library.
   * The :ref:`Modem API <nrf_modem_api>` (:file:`nrf_modem.h`) has been updated to return negative errno values on error.
-  * The :ref:`Full Modem DFU API <nrf_modem_full_dfu_api>` (:file:`nrf_modem_full_dfu.h`) has been updated to return negative errno values on error.
+  * The :ref:`Full Modem DFU API <nrf_modem_bootloader_api>` (:file:`nrf_modem_bootloader.h`) has been updated to return negative errno values on error.
   * The :ref:`GNSS API <nrf_modem_gnss_api>` (:file:`nrf_modem_gnss.h`) has been updated to return negative errno values on error.
 
 * Removed:

--- a/doc/nrf/ug_nrf91_features.rst
+++ b/doc/nrf/ug_nrf91_features.rst
@@ -130,7 +130,7 @@ Full upgrade
   * When using a wireless connection, the upgrade is applied over-the-air (OTA).
     See :ref:`nrf9160_fota` for more information.
 
- See :ref:`nrfxlib:full_dfu` for more information on the full firmware updates of modem using :ref:`nrfxlib:nrf_modem`.
+ See :ref:`nrfxlib:bootloader` for more information on the full firmware updates of modem using :ref:`nrfxlib:nrf_modem`.
 
 Delta patches
   Delta patches are upgrades that contain only the difference from the last version.

--- a/doc/nrfxlib/known-warnings.txt
+++ b/doc/nrfxlib/known-warnings.txt
@@ -1,6 +1,6 @@
 # Each line should contain the regular expression of a known Sphinx warning
 # that should be filtered out
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_full_dfu_digest'.*
-.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_full_dfu_uuid'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_bootloader_digest'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_bootloader_uuid'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: nrf_modem_delta_dfu_uuid'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: union mpsl_fem_event_t.@[0-9]+ event'.*

--- a/include/mgmt/fmfu_mgmt.h
+++ b/include/mgmt/fmfu_mgmt.h
@@ -28,7 +28,7 @@ extern "C" {
  *  update command handler group.
  *
  * The modem library must be initialized in DFU mode before calling this
- * function - nrf_modem_lib_init(FULL_DFU_MODE).
+ * function - nrf_modem_lib_init(BOOTLOADER_MODE).
  *
  * @retval 0 on success, negative integer on failure.
  */

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -28,6 +28,15 @@ extern "C" {
  * @brief API of the SMS nRF Modem library wrapper module.
  */
 
+
+/** @brief Modem library mode */
+enum nrf_modem_mode {
+	/** Normal operation mode */
+	NORMAL_MODE,
+	/** Bootloader (full DFU) mode */
+	BOOTLOADER_MODE,
+};
+
 /**
  * @brief Initialize the Modem library.
  *

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -62,6 +62,13 @@ static const struct nrf_modem_init_params init_params = {
 	.fault_handler = nrf_modem_fault_handler
 };
 
+static const struct nrf_modem_bootloader_init_params bootloader_init_params = {
+	.ipc_irq_prio = CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO,
+	.shmem.base = PM_NRF_MODEM_LIB_SRAM_ADDRESS,
+	.shmem.size = PM_NRF_MODEM_LIB_SRAM_SIZE,
+	.fault_handler = nrf_modem_fault_handler
+};
+
 static void log_fw_version_uuid(void)
 {
 	int err;
@@ -121,7 +128,7 @@ static int _nrf_modem_lib_init(const struct device *unused)
 	IRQ_CONNECT(NRF_MODEM_IPC_IRQ, CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO,
 		    nrfx_isr, nrfx_ipc_irq_handler, 0);
 
-	init_ret = nrf_modem_init(&init_params, NORMAL_MODE);
+	init_ret = nrf_modem_init(&init_params);
 
 	if (IS_ENABLED(CONFIG_NRF_MODEM_LIB_LOG_FW_VERSION_UUID)) {
 		log_fw_version_uuid();
@@ -180,7 +187,7 @@ int nrf_modem_lib_init(enum nrf_modem_mode mode)
 	if (mode == NORMAL_MODE) {
 		return _nrf_modem_lib_init(NULL);
 	} else {
-		return nrf_modem_init(&init_params, FULL_DFU_MODE);
+		return nrf_modem_bootloader_init(&bootloader_init_params);
 	}
 }
 

--- a/samples/nrf9160/fmfu_smp_svr/src/main.c
+++ b/samples/nrf9160/fmfu_smp_svr/src/main.c
@@ -34,7 +34,7 @@ void main(void)
 	/* Shutdown modem to prepare for DFU */
 	nrf_modem_lib_shutdown();
 
-	nrf_modem_lib_init(FULL_DFU_MODE);
+	nrf_modem_lib_init(BOOTLOADER_MODE);
 	/* Register SMP Communication stats */
 	fmfu_mgmt_stat_init();
 	/* Registers the OS management command handler group */

--- a/samples/nrf9160/http_update/full_modem_update/src/main.c
+++ b/samples/nrf9160/http_update/full_modem_update/src/main.c
@@ -9,7 +9,7 @@
 #include <dfu/dfu_target_full_modem.h>
 #include <net/fota_download.h>
 #include <zephyr/shell/shell.h>
-#include <nrf_modem_full_dfu.h>
+#include <nrf_modem_bootloader.h>
 #include <modem/modem_info.h>
 #include <dfu/fmfu_fdev.h>
 #include <zephyr/drivers/gpio.h>
@@ -65,9 +65,9 @@ static void apply_fmfu_from_ext_flash(bool valid_init)
 		}
 	}
 
-	err = nrf_modem_lib_init(FULL_DFU_MODE);
+	err = nrf_modem_lib_init(BOOTLOADER_MODE);
 	if (err != 0) {
-		printk("nrf_modem_lib_init(FULL_DFU_MODE) failed: %d\n", err);
+		printk("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d\n", err);
 		return;
 	}
 

--- a/subsys/dfu/fmfu_fdev/src/fmfu_fdev.c
+++ b/subsys/dfu/fmfu_fdev/src/fmfu_fdev.c
@@ -62,13 +62,13 @@ static int write_chunk(uint8_t *buf, size_t buf_len, uint32_t address,
 	int err;
 
 	if (is_bootloader) {
-		err = nrf_modem_bootloader_bl_write(buf_len, buf);
+		err = nrf_modem_bootloader_bl_write(buf, buf_len);
 		if (err != 0) {
 			LOG_ERR("nrf_modem_bootloader_bl_write failed, err: %d", err);
 			return err;
 		}
 	} else {
-		err = nrf_modem_bootloader_fw_write(address, buf_len, buf);
+		err = nrf_modem_bootloader_fw_write(address, buf, buf_len);
 		if (err != 0) {
 			LOG_ERR("nrf_modem_bootloader_fw_write failed, err: %d", err);
 			return err;
@@ -155,8 +155,7 @@ static int load_segments(const struct device *fdev, uint8_t *meta_buf,
 			 * perform the prevalidation.
 			 */
 			LOG_INF("Running prevalidation (can take minutes)");
-			err = nrf_modem_bootloader_verify(wrapper_len,
-							(void *)meta_buf);
+			err = nrf_modem_bootloader_verify((void *)meta_buf, wrapper_len);
 			if (err != 0) {
 				LOG_ERR("nrf_fmfu_verify_signature failed, err: %d", err);
 				return err;

--- a/subsys/dfu/fmfu_fdev/src/fmfu_fdev.c
+++ b/subsys/dfu/fmfu_fdev/src/fmfu_fdev.c
@@ -7,7 +7,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/logging/log.h>
 #include <dfu/fmfu_fdev.h>
-#include <nrf_modem_full_dfu.h>
+#include <nrf_modem_bootloader.h>
 #include <mbedtls/sha256.h>
 #include <stdio.h>
 #include <modem_update_decode.h>
@@ -62,15 +62,15 @@ static int write_chunk(uint8_t *buf, size_t buf_len, uint32_t address,
 	int err;
 
 	if (is_bootloader) {
-		err = nrf_modem_full_dfu_bl_write(buf_len, buf);
+		err = nrf_modem_bootloader_bl_write(buf_len, buf);
 		if (err != 0) {
-			LOG_ERR("nrf_...dfu_bl_write failed, err: %d", err);
+			LOG_ERR("nrf_modem_bootloader_bl_write failed, err: %d", err);
 			return err;
 		}
 	} else {
-		err = nrf_modem_full_dfu_fw_write(address, buf_len, buf);
+		err = nrf_modem_bootloader_fw_write(address, buf_len, buf);
 		if (err != 0) {
-			LOG_ERR("nrf...full_dfu_fw_write failed, err: %d", err);
+			LOG_ERR("nrf_modem_bootloader_fw_write failed, err: %d", err);
 			return err;
 		}
 	}
@@ -114,9 +114,9 @@ static int load_segment(const struct device *fdev, size_t seg_size,
 		/* We need to explicitly call _apply() once all chunks of the
 		 * bootloader has been written.
 		 */
-		err = nrf_modem_full_dfu_apply();
+		err = nrf_modem_bootloader_update();
 		if (err != 0) {
-			LOG_ERR("nrf_..._full_dfu_apply (bl) failed, err: %d", err);
+			LOG_ERR("nrf_modem_bootloader_update (bl) failed, err: %d", err);
 			return err;
 		}
 	}
@@ -155,7 +155,7 @@ static int load_segments(const struct device *fdev, uint8_t *meta_buf,
 			 * perform the prevalidation.
 			 */
 			LOG_INF("Running prevalidation (can take minutes)");
-			err = nrf_modem_full_dfu_verify(wrapper_len,
+			err = nrf_modem_bootloader_verify(wrapper_len,
 							(void *)meta_buf);
 			if (err != 0) {
 				LOG_ERR("nrf_fmfu_verify_signature failed, err: %d", err);
@@ -169,9 +169,9 @@ static int load_segments(const struct device *fdev, uint8_t *meta_buf,
 		prev_segments_len += seg_size;
 	}
 
-	err = nrf_modem_full_dfu_apply();
+	err = nrf_modem_bootloader_update();
 	if (err != 0) {
-		LOG_ERR("nrf_..._full_dfu_apply (fw) failed, err: %d", err);
+		LOG_ERR("nrf_modem_bootloader_update (fw) failed, err: %d", err);
 		return err;
 	}
 
@@ -197,13 +197,6 @@ int fmfu_fdev_load(uint8_t *buf, size_t buf_len, const struct device *fdev,
 
 	if (buf == NULL || fdev == NULL) {
 		return -ENOMEM;
-	}
-
-	/* Put modem in DFU/RPC state */
-	err = nrf_modem_full_dfu_init(NULL);
-	if (err != 0) {
-		LOG_ERR("nrf_modem_full_dfu_init failed, err: %d.", err);
-		return err;
 	}
 
 	/* Read the whole wrapper. */

--- a/subsys/mgmt/fmfu/src/fmfu_mgmt.c
+++ b/subsys/mgmt/fmfu/src/fmfu_mgmt.c
@@ -116,8 +116,7 @@ static int fmfu_firmware_upload(struct mgmt_ctxt *ctx)
 
 	if (packet.data_len > 0) {
 		if (bootloader) {
-			rc = nrf_modem_bootloader_bl_write(packet.data_len,
-					packet.data);
+			rc = nrf_modem_bootloader_bl_write(packet.data, packet.data_len);
 			if (rc != 0) {
 				LOG_ERR("Error in starting transfer");
 				return MGMT_ERR_EBADSTATE;
@@ -129,8 +128,8 @@ static int fmfu_firmware_upload(struct mgmt_ctxt *ctx)
 						  packet.data_len);
 
 			rc = nrf_modem_bootloader_fw_write(packet.target_address,
-							 packet.data_len,
-							 packet.data);
+							   packet.data,
+							   packet.data_len);
 			if (rc != 0) {
 				LOG_ERR("Error in writing data, err: %d", rc);
 				return MGMT_ERR_EBADSTATE;

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -25,7 +25,7 @@
 
 #if defined(CONFIG_DFU_TARGET_FULL_MODEM)
 #include <dfu/dfu_target_full_modem.h>
-#include <nrf_modem_full_dfu.h>
+#include <nrf_modem_bootloader.h>
 #include <dfu/fmfu_fdev.h>
 #include <string.h>
 #endif
@@ -380,9 +380,9 @@ static uint8_t apply_fmfu_from_ext_flash(void)
 		return RESULT_UPDATE_FAILED;
 	}
 
-	ret = nrf_modem_lib_init(FULL_DFU_MODE);
+	ret = nrf_modem_lib_init(BOOTLOADER_MODE);
 	if (ret != 0) {
-		LOG_ERR("nrf_modem_lib_init(FULL_DFU_MODE) failed: %d\n", ret);
+		LOG_ERR("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d\n", ret);
 		return RESULT_UPDATE_FAILED;
 	}
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -92,9 +92,9 @@ int nrf_cloud_fota_fmfu_apply(void)
 		return err;
 	}
 
-	err = nrf_modem_lib_init(FULL_DFU_MODE);
+	err = nrf_modem_lib_init(BOOTLOADER_MODE);
 	if (err != 0) {
-		LOG_ERR("nrf_modem_lib_init(FULL_DFU_MODE) failed: %d", err);
+		LOG_ERR("nrf_modem_lib_init(BOOTLOADER_MODE) failed: %d", err);
 		(void)nrf_modem_lib_init(NORMAL_MODE);
 		return err;
 	}

--- a/west.yml
+++ b/west.yml
@@ -119,7 +119,7 @@ manifest:
       repo-path: sdk-nrfxlib
       path: nrfxlib
       remote: lemrey
-      revision: libmodem
+      revision: 715408045d568ed1ab78063239be4d78464ffaa2
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Split the bootloader initialization from the normal library initialization. The bootloader mode requires the shared memory to be one larger chunk, compared to the normal mode, that split the shared memory in four.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>