### PR TITLE
samples: nrf9160: http_update: Add support for carrier library

### DIFF
--- a/doc/nrf/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases/release-notes-changelog.rst
@@ -336,6 +336,24 @@ nRF9160 samples
     * Added handling for the new data receive events in the :ref:`lib_nrf_cloud` library.
     * Removed A-GPS and P-GPS processing; it is now handled by the :ref:`lib_nrf_cloud` library.
 
+* :ref:`http_application_update_sample`:
+
+  * Added:
+
+    * Support for the :ref:`liblwm2m_carrier_readme` library.
+
+* :ref:`http_full_modem_update_sample`:
+
+  * Added:
+
+    * Support for the :ref:`liblwm2m_carrier_readme` library.
+
+* :ref:`http_modem_delta_update_sample`:
+
+  * Added:
+
+    * Support for the :ref:`liblwm2m_carrier_readme` library.
+
 Thread samples
 --------------
 

--- a/samples/nrf9160/http_update/application_update/README.rst
+++ b/samples/nrf9160/http_update/application_update/README.rst
@@ -121,6 +121,28 @@ After programming the sample to your development kit, test it by performing the 
    This indicates that the application image has been downgraded to version 1.
    Any further updates will toggle between the versions.
 
+Using the carrier library
+=========================
+
+The sample supports the |NCS| :ref:`liblwm2m_carrier_readme` library that you can use to connect to the operator's device management platform.
+See the library's documentation for more information and configuration options.
+
+To enable the LwM2M carrier library, add the parameter ``-DOVERLAY_CONFIG=overlay-carrier.conf`` to your build command.
+
+The CA root certificates that are needed for modem FOTA are not provisioned in the HTTP application update sample.
+You can flash the :ref:`lwm2m_carrier` sample to write the certificates to modem before flashing the HTTP application update sample,
+or use the :ref:`at_client_sample` sample as explained in :ref:`Preparing the nRF9160: LwM2M Client sample for production <lwm2m_client_provisioning>`.
+It is also possible to modify the HTTP application update project itself to include the certificate provisioning, as demonstrated in the :ref:`lwm2m_carrier` sample.
+
+.. code-block:: c
+
+   int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
+   {
+           switch (event->type) {
+           case LWM2M_CARRIER_EVENT_INIT:
+                   carrier_cert_provision();
+           ...
+
 Dependencies
 ************
 

--- a/samples/nrf9160/http_update/application_update/overlay-carrier.conf
+++ b/samples/nrf9160/http_update/application_update/overlay-carrier.conf
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_LWM2M_CARRIER=y
+
+# Workaround for known issue NCSDK-16916.
+# Set the size of the storage partition to a multiple of CONFIG_NRF_SPU_FLASH_REGION_SIZE.
+CONFIG_LWM2M_CARRIER_STORAGE_AREA_SIZE=0x8000
+
+# LwM2M carrier is only compiled for hard-float
+CONFIG_FPU=y
+CONFIG_FP_HARDABI=y
+
+# SMS library
+CONFIG_SMS=y
+
+# PDN management support
+CONFIG_PDN=y
+
+# AT Monitor is used by PDN library
+CONFIG_AT_MONITOR=y
+CONFIG_AT_MONITOR_HEAP_SIZE=320
+
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+
+# Download client for DFU
+CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE=230
+
+# Modem info
+CONFIG_MODEM_INFO_BUFFER_SIZE=512
+
+# Disable AT host library as it's incompatible with the carrier library's
+# requirement to initialize the modem library
+CONFIG_AT_HOST_LIBRARY=n
+
+# Non-volatile Storage
+CONFIG_NVS=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+
+# Default partition for NVS is unused
+CONFIG_PM_PARTITION_SIZE_NVS_STORAGE=0
+
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1536
+
+CONFIG_LWM2M_CARRIER_SETTINGS=n

--- a/samples/nrf9160/http_update/application_update/src/main.c
+++ b/samples/nrf9160/http_update/application_update/src/main.c
@@ -11,6 +11,10 @@
 #include <stdio.h>
 #include "update.h"
 
+#if defined(CONFIG_LWM2M_CARRIER)
+#include <lwm2m_carrier.h>
+#endif
+
 #if CONFIG_APPLICATION_VERSION == 2
 #define NUM_LEDS 2
 #else
@@ -44,6 +48,131 @@ static void fota_dl_handler(const struct fota_download_evt *evt)
 	}
 }
 
+#if defined(CONFIG_LWM2M_CARRIER)
+void nrf_modem_recoverable_error_handler(uint32_t err)
+{
+	printk("Modem library recoverable error: %u\n", (unsigned int)err);
+}
+
+static void lte_event_handler(const struct lte_lc_evt *const evt)
+{
+	/* This event handler is not in use here. */
+	ARG_UNUSED(evt);
+}
+
+void print_err(const lwm2m_carrier_event_t *evt)
+{
+	const lwm2m_carrier_event_error_t *err = evt->data.error;
+
+	static const char *strerr[] = {
+		[LWM2M_CARRIER_ERROR_NO_ERROR] =
+			"No error",
+		[LWM2M_CARRIER_ERROR_BOOTSTRAP] =
+			"Bootstrap error",
+		[LWM2M_CARRIER_ERROR_LTE_LINK_UP_FAIL] =
+			"Failed to connect to the LTE network",
+		[LWM2M_CARRIER_ERROR_LTE_LINK_DOWN_FAIL] =
+			"Failed to disconnect from the LTE network",
+		[LWM2M_CARRIER_ERROR_FOTA_PKG] =
+			"Package refused from modem",
+		[LWM2M_CARRIER_ERROR_FOTA_PROTO] =
+			"Protocol error",
+		[LWM2M_CARRIER_ERROR_FOTA_CONN] =
+			"Connection to remote server failed",
+		[LWM2M_CARRIER_ERROR_FOTA_CONN_LOST] =
+			"Connection to remote server lost",
+		[LWM2M_CARRIER_ERROR_FOTA_FAIL] =
+			"Modem firmware update failed",
+		[LWM2M_CARRIER_ERROR_CONFIGURATION] =
+			"Illegal object configuration detected",
+		[LWM2M_CARRIER_ERROR_INIT] =
+			"Initialization failure",
+		[LWM2M_CARRIER_ERROR_INTERNAL] =
+			"Internal failure",
+	};
+
+	printk("%s, reason %d\n", strerr[err->type], err->value);
+}
+
+void print_deferred(const lwm2m_carrier_event_t *evt)
+{
+	const lwm2m_carrier_event_deferred_t *def = evt->data.deferred;
+
+	static const char *strdef[] = {
+		[LWM2M_CARRIER_DEFERRED_NO_REASON] =
+			"No reason given",
+		[LWM2M_CARRIER_DEFERRED_PDN_ACTIVATE] =
+			"Failed to activate PDN",
+		[LWM2M_CARRIER_DEFERRED_BOOTSTRAP_NO_ROUTE] =
+			"No route to bootstrap server",
+		[LWM2M_CARRIER_DEFERRED_BOOTSTRAP_CONNECT] =
+			"Failed to connect to bootstrap server",
+		[LWM2M_CARRIER_DEFERRED_BOOTSTRAP_SEQUENCE] =
+			"Bootstrap sequence not completed",
+		[LWM2M_CARRIER_DEFERRED_SERVER_NO_ROUTE] =
+			"No route to server",
+		[LWM2M_CARRIER_DEFERRED_SERVER_CONNECT] =
+			"Failed to connect to server",
+		[LWM2M_CARRIER_DEFERRED_SERVER_REGISTRATION] =
+			"Server registration sequence not completed",
+		[LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE] =
+			"Server in maintenance mode",
+		[LWM2M_CARRIER_DEFERRED_SIM_MSISDN] =
+			"Waiting for SIM MSISDN",
+	};
+
+	printk("Reason: %s, timeout: %d seconds\n", strdef[def->reason],
+		def->timeout);
+}
+
+int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
+{
+	int err = 0;
+
+	switch (event->type) {
+	case LWM2M_CARRIER_EVENT_INIT:
+		printk("LWM2M_CARRIER_EVENT_INIT\n");
+		err = lte_lc_init();
+		lte_lc_register_handler(lte_event_handler);
+		break;
+	case LWM2M_CARRIER_EVENT_LTE_LINK_UP:
+		printk("LWM2M_CARRIER_EVENT_LTE_LINK_UP\n");
+		err = lte_lc_connect_async(NULL);
+		break;
+	case LWM2M_CARRIER_EVENT_LTE_LINK_DOWN:
+		printk("LWM2M_CARRIER_EVENT_LTE_LINK_DOWN\n");
+		err = lte_lc_offline();
+		break;
+	case LWM2M_CARRIER_EVENT_LTE_POWER_OFF:
+		printk("LWM2M_CARRIER_EVENT_LTE_POWER_OFF\n");
+		err = lte_lc_power_off();
+		break;
+	case LWM2M_CARRIER_EVENT_BOOTSTRAPPED:
+		printk("LWM2M_CARRIER_EVENT_BOOTSTRAPPED\n");
+		break;
+	case LWM2M_CARRIER_EVENT_REGISTERED:
+		printk("LWM2M_CARRIER_EVENT_REGISTERED\n");
+		break;
+	case LWM2M_CARRIER_EVENT_DEFERRED:
+		printk("LWM2M_CARRIER_EVENT_DEFERRED\n");
+		print_deferred(event);
+		break;
+	case LWM2M_CARRIER_EVENT_FOTA_START:
+		printk("LWM2M_CARRIER_EVENT_FOTA_START\n");
+		break;
+	case LWM2M_CARRIER_EVENT_REBOOT:
+		printk("LWM2M_CARRIER_EVENT_REBOOT\n");
+		break;
+	case LWM2M_CARRIER_EVENT_ERROR:
+		printk("LWM2M_CARRIER_EVENT_ERROR\n");
+		print_err(event);
+		break;
+	}
+
+	return err;
+}
+#endif /* CONFIG_LWM2M_CARRIER */
+
 void main(void)
 {
 	int err;
@@ -51,11 +180,13 @@ void main(void)
 	printk("HTTP application update sample started\n");
 	printk("Using version %d\n", CONFIG_APPLICATION_VERSION);
 
+#if !defined(CONFIG_LWM2M_CARRIER)
 	err = nrf_modem_lib_init(NORMAL_MODE);
 	if (err) {
 		printk("Failed to initialize modem library!");
 		return;
 	}
+#endif
 	/* This is needed so that MCUBoot won't revert the update */
 	boot_write_img_confirmed();
 

--- a/samples/nrf9160/http_update/common/src/update.c
+++ b/samples/nrf9160/http_update/common/src/update.c
@@ -142,6 +142,7 @@ static int button_init(void)
  */
 static void modem_configure(void)
 {
+#if !defined(CONFIG_LWM2M_CARRIER)
 #if defined(CONFIG_LTE_LINK_CONTROL)
 	BUILD_ASSERT(!IS_ENABLED(CONFIG_LTE_AUTO_INIT_AND_CONNECT),
 			"This sample does not support auto init and connect");
@@ -150,13 +151,14 @@ static void modem_configure(void)
 #if defined(CONFIG_USE_HTTPS)
 	err = cert_provision();
 	__ASSERT(err == 0, "Could not provision root CA to %d", TLS_SEC_TAG);
-#endif
+#endif /* CONFIG_USE_HTTPS */
 
 	printk("LTE Link Connecting ...\n");
 	err = lte_lc_init_and_connect();
 	__ASSERT(err == 0, "LTE link could not be established.");
 	printk("LTE Link Connected!\n");
-#endif
+#endif /* CONFIG_LTE_LINK_CONTROL */
+#endif /* CONFIG_LWM2M_CARRIER */
 }
 
 static void fota_work_cb(struct k_work *work)
@@ -239,5 +241,7 @@ void update_sample_stop(void)
 
 void update_sample_done(void)
 {
+#if !defined(CONFIG_LWM2M_CARRIER)
 	lte_lc_deinit();
+#endif
 }

--- a/samples/nrf9160/http_update/full_modem_update/README.rst
+++ b/samples/nrf9160/http_update/full_modem_update/README.rst
@@ -91,6 +91,28 @@ Testing
 #. Press the **Reset** button or type "reset" in the terminal emulator to reset the development kit.
 #. Observe that the LED pattern has changed.
 
+Using the carrier library
+=========================
+
+The sample supports the |NCS| :ref:`liblwm2m_carrier_readme` library that you can use to connect to the operator's device management platform.
+See the library's documentation for more information and configuration options.
+
+To enable the LwM2M carrier library, add the parameter ``-DOVERLAY_CONFIG=overlay-carrier.conf`` to your build command.
+
+The CA root certificates that are needed for modem FOTA are not provisioned in the HTTP full modem update sample.
+You can flash the :ref:`lwm2m_carrier` sample to write the certificates to modem before flashing the HTTP full modem update sample,
+or use the :ref:`at_client_sample` sample as explained in :ref:`Preparing the nRF9160: LwM2M Client sample for production <lwm2m_client_provisioning>`.
+It is also possible to modify the HTTP full modem update project itself to include the certificate provisioning, as demonstrated in the :ref:`lwm2m_carrier` sample.
+
+.. code-block:: c
+
+   int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
+   {
+           switch (event->type) {
+           case LWM2M_CARRIER_EVENT_INIT:
+                   carrier_cert_provision();
+           ...
+
 Dependencies
 ************
 

--- a/samples/nrf9160/http_update/full_modem_update/overlay-carrier.conf
+++ b/samples/nrf9160/http_update/full_modem_update/overlay-carrier.conf
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_LWM2M_CARRIER=y
+
+# Workaround for known issue NCSDK-16916.
+# Set the size of the storage partition to a multiple of CONFIG_NRF_SPU_FLASH_REGION_SIZE.
+CONFIG_LWM2M_CARRIER_STORAGE_AREA_SIZE=0x8000
+
+# LwM2M carrier is only compiled for hard-float
+CONFIG_FPU=y
+CONFIG_FP_HARDABI=y
+
+# SMS library
+CONFIG_SMS=y
+
+# PDN management support
+CONFIG_PDN=y
+
+# AT Monitor is used by PDN library
+CONFIG_AT_MONITOR=y
+CONFIG_AT_MONITOR_HEAP_SIZE=320
+
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+
+# Download client for DFU
+CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE=230
+
+# Modem info
+CONFIG_MODEM_INFO_BUFFER_SIZE=512
+
+# Disable AT host library as it's incompatible with the carrier library's
+# requirement to initialize the modem library
+CONFIG_AT_HOST_LIBRARY=n
+
+# Non-volatile Storage
+CONFIG_NVS=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+
+# Default partition for NVS is unused
+CONFIG_PM_PARTITION_SIZE_NVS_STORAGE=0
+
+CONFIG_LWM2M_CARRIER_SETTINGS=n

--- a/samples/nrf9160/http_update/full_modem_update/src/main.c
+++ b/samples/nrf9160/http_update/full_modem_update/src/main.c
@@ -19,6 +19,10 @@
 #include <string.h>
 #include <update.h>
 
+#if defined(CONFIG_LWM2M_CARRIER)
+#include <lwm2m_carrier.h>
+#endif
+
 /* We assume that modem version strings (not UUID) will not be more than this */
 #define MAX_MODEM_VERSION_LEN 256
 
@@ -27,6 +31,8 @@ static const struct gpio_dt_spec sw1 = GPIO_DT_SPEC_GET(DT_ALIAS(sw1), gpios);
 static struct gpio_callback sw1_cb;
 static const struct device *flash_dev = DEVICE_DT_GET_ONE(jedec_spi_nor);
 static char modem_version[MAX_MODEM_VERSION_LEN];
+
+static K_SEM_DEFINE(started_sample, 0, 1);
 
 /* Buffer used as temporary storage when downloading the modem firmware, and
  * when loading the modem firmware from external flash to the modem.
@@ -193,6 +199,131 @@ static int shell_flash(const struct shell *shell, size_t argc, char **argv)
 
 SHELL_CMD_REGISTER(flash, NULL, "For rebooting device", shell_flash);
 
+#ifdef CONFIG_LWM2M_CARRIER
+void nrf_modem_recoverable_error_handler(uint32_t err)
+{
+	printk("Modem library recoverable error: %u\n", (unsigned int)err);
+}
+
+static void lte_event_handler(const struct lte_lc_evt *const evt)
+{
+	/* This event handler is not in use here. */
+	ARG_UNUSED(evt);
+}
+
+void print_err(const lwm2m_carrier_event_t *evt)
+{
+	const lwm2m_carrier_event_error_t *err = evt->data.error;
+
+	static const char *strerr[] = {
+		[LWM2M_CARRIER_ERROR_NO_ERROR] =
+			"No error",
+		[LWM2M_CARRIER_ERROR_BOOTSTRAP] =
+			"Bootstrap error",
+		[LWM2M_CARRIER_ERROR_LTE_LINK_UP_FAIL] =
+			"Failed to connect to the LTE network",
+		[LWM2M_CARRIER_ERROR_LTE_LINK_DOWN_FAIL] =
+			"Failed to disconnect from the LTE network",
+		[LWM2M_CARRIER_ERROR_FOTA_PKG] =
+			"Package refused from modem",
+		[LWM2M_CARRIER_ERROR_FOTA_PROTO] =
+			"Protocol error",
+		[LWM2M_CARRIER_ERROR_FOTA_CONN] =
+			"Connection to remote server failed",
+		[LWM2M_CARRIER_ERROR_FOTA_CONN_LOST] =
+			"Connection to remote server lost",
+		[LWM2M_CARRIER_ERROR_FOTA_FAIL] =
+			"Modem firmware update failed",
+		[LWM2M_CARRIER_ERROR_CONFIGURATION] =
+			"Illegal object configuration detected",
+		[LWM2M_CARRIER_ERROR_INIT] =
+			"Initialization failure",
+		[LWM2M_CARRIER_ERROR_INTERNAL] =
+			"Internal failure",
+	};
+
+	printk("%s, reason %d\n", strerr[err->type], err->value);
+}
+
+void print_deferred(const lwm2m_carrier_event_t *evt)
+{
+	const lwm2m_carrier_event_deferred_t *def = evt->data.deferred;
+
+	static const char *strdef[] = {
+		[LWM2M_CARRIER_DEFERRED_NO_REASON] =
+			"No reason given",
+		[LWM2M_CARRIER_DEFERRED_PDN_ACTIVATE] =
+			"Failed to activate PDN",
+		[LWM2M_CARRIER_DEFERRED_BOOTSTRAP_NO_ROUTE] =
+			"No route to bootstrap server",
+		[LWM2M_CARRIER_DEFERRED_BOOTSTRAP_CONNECT] =
+			"Failed to connect to bootstrap server",
+		[LWM2M_CARRIER_DEFERRED_BOOTSTRAP_SEQUENCE] =
+			"Bootstrap sequence not completed",
+		[LWM2M_CARRIER_DEFERRED_SERVER_NO_ROUTE] =
+			"No route to server",
+		[LWM2M_CARRIER_DEFERRED_SERVER_CONNECT] =
+			"Failed to connect to server",
+		[LWM2M_CARRIER_DEFERRED_SERVER_REGISTRATION] =
+			"Server registration sequence not completed",
+		[LWM2M_CARRIER_DEFERRED_SERVICE_UNAVAILABLE] =
+			"Server in maintenance mode",
+		[LWM2M_CARRIER_DEFERRED_SIM_MSISDN] =
+			"Waiting for SIM MSISDN",
+	};
+
+	printk("Reason: %s, timeout: %d seconds\n", strdef[def->reason],
+		def->timeout);
+}
+
+int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
+{
+	int err = 0;
+
+	switch (event->type) {
+	case LWM2M_CARRIER_EVENT_INIT:
+		printk("LWM2M_CARRIER_EVENT_INIT\n");
+		err = lte_lc_init();
+		lte_lc_register_handler(lte_event_handler);
+		break;
+	case LWM2M_CARRIER_EVENT_LTE_LINK_UP:
+		printk("LWM2M_CARRIER_EVENT_LTE_LINK_UP\n");
+		err = lte_lc_connect_async(NULL);
+		break;
+	case LWM2M_CARRIER_EVENT_LTE_LINK_DOWN:
+		printk("LWM2M_CARRIER_EVENT_LTE_LINK_DOWN\n");
+		err = lte_lc_offline();
+		break;
+	case LWM2M_CARRIER_EVENT_LTE_POWER_OFF:
+		printk("LWM2M_CARRIER_EVENT_LTE_POWER_OFF\n");
+		err = lte_lc_power_off();
+		break;
+	case LWM2M_CARRIER_EVENT_BOOTSTRAPPED:
+		printk("LWM2M_CARRIER_EVENT_BOOTSTRAPPED\n");
+		break;
+	case LWM2M_CARRIER_EVENT_REGISTERED:
+		printk("LWM2M_CARRIER_EVENT_REGISTERED\n");
+		break;
+	case LWM2M_CARRIER_EVENT_DEFERRED:
+		printk("LWM2M_CARRIER_EVENT_DEFERRED\n");
+		print_deferred(event);
+		break;
+	case LWM2M_CARRIER_EVENT_FOTA_START:
+		printk("LWM2M_CARRIER_EVENT_FOTA_START\n");
+		break;
+	case LWM2M_CARRIER_EVENT_REBOOT:
+		printk("LWM2M_CARRIER_EVENT_REBOOT\n");
+		break;
+	case LWM2M_CARRIER_EVENT_ERROR:
+		printk("LWM2M_CARRIER_EVENT_ERROR\n");
+		print_err(event);
+		break;
+	}
+
+	return err;
+}
+#endif /* CONFIG_LWM2M_CARRIER */
+
 void main(void)
 {
 	int err;
@@ -204,6 +335,7 @@ void main(void)
 		return;
 	}
 
+#if !defined(CONFIG_LWM2M_CARRIER)
 	err = nrf_modem_lib_init(NORMAL_MODE);
 	if (err) {
 		printk("Failed to initialize modem lib, err: %d\n", err);
@@ -211,6 +343,9 @@ void main(void)
 		printk("Trying to apply modem update from ext flash\n");
 		apply_fmfu_from_ext_flash(false);
 	}
+#endif
+
+	k_sem_take(&started_sample, K_SECONDS(1));
 
 	k_work_init(&fmfu_work, fmfu_work_cb);
 

--- a/samples/nrf9160/http_update/modem_delta_update/README.rst
+++ b/samples/nrf9160/http_update/modem_delta_update/README.rst
@@ -46,6 +46,28 @@ After programming the sample to your development kit,, test it by performing the
 #. Observe that the LED pattern has changed (1 vs 2).
 #. Start over from point 1, to perform the delta update back to the previous version.
 
+Using the carrier library
+=========================
+
+The sample supports the |NCS| :ref:`liblwm2m_carrier_readme` library that you can use to connect to the operator's device management platform.
+See the library's documentation for more information and configuration options.
+
+To enable the LwM2M carrier library, add the parameter ``-DOVERLAY_CONFIG=overlay-carrier.conf`` to your build command.
+
+The CA root certificates that are needed for modem FOTA are not provisioned in the HTTP modem delta update sample.
+You can flash the :ref:`lwm2m_carrier` sample to write the certificates to modem before flashing the HTTP modem delta update sample,
+or use the :ref:`at_client_sample` sample as explained in :ref:`Preparing the nRF9160: LwM2M Client sample for production <lwm2m_client_provisioning>`.
+It is also possible to modify the HTTP modem delta update project itself to include the certificate provisioning, as demonstrated in the :ref:`lwm2m_carrier` sample.
+
+.. code-block:: c
+
+   int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
+   {
+           switch (event->type) {
+           case LWM2M_CARRIER_EVENT_INIT:
+                   carrier_cert_provision();
+           ...
+
 Dependencies
 ************
 

--- a/samples/nrf9160/http_update/modem_delta_update/overlay-carrier.conf
+++ b/samples/nrf9160/http_update/modem_delta_update/overlay-carrier.conf
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+CONFIG_LWM2M_CARRIER=y
+
+# Workaround for known issue NCSDK-16916.
+# Set the size of the storage partition to a multiple of CONFIG_NRF_SPU_FLASH_REGION_SIZE.
+CONFIG_LWM2M_CARRIER_STORAGE_AREA_SIZE=0x8000
+
+# LwM2M carrier is only compiled for hard-float
+CONFIG_FPU=y
+CONFIG_FP_HARDABI=y
+
+# SMS library
+CONFIG_SMS=y
+
+# PDN management support
+CONFIG_PDN=y
+
+# AT Monitor is used by PDN library
+CONFIG_AT_MONITOR=y
+CONFIG_AT_MONITOR_HEAP_SIZE=320
+
+CONFIG_HEAP_MEM_POOL_SIZE=4096
+
+# Download client for DFU
+CONFIG_DOWNLOAD_CLIENT_MAX_FILENAME_SIZE=230
+
+# Modem info
+CONFIG_MODEM_INFO_BUFFER_SIZE=512
+
+# Disable AT host library as it's incompatible with the carrier library's
+# requirement to initialize the modem library
+CONFIG_AT_HOST_LIBRARY=n
+
+# Non-volatile Storage
+CONFIG_NVS=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+
+# Default partition for NVS is unused
+CONFIG_PM_PARTITION_SIZE_NVS_STORAGE=0
+
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=1536
+
+CONFIG_LWM2M_CARRIER_SETTINGS=n
+
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y


### PR DESCRIPTION
This will add support for the LwM2M carrier library to all three HTTP Update samples.

Signed-off-by: Markus Rekdal <markus.rekdal@nordicsemi.no>