### PR TITLE
lib: nrf_modem: fix unresponsive diagnostics 

### DIFF
--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -174,6 +174,8 @@ struct nrf_modem_lib_diag_stats {
  * @brief Retrieve heap runtime statistics.
  *
  * Retrieve runtime statistics for the shared memory and library heaps.
+ * 
+ * @return int Zero on success, non-zero otherwise.
  */
 int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats);
 

--- a/lib/nrf_modem_lib/diag.c
+++ b/lib/nrf_modem_lib/diag.c
@@ -27,6 +27,11 @@ static struct k_work_delayable diag_work;
 
 int nrf_modem_lib_diag_stats_get(struct nrf_modem_lib_diag_stats *stats)
 {
+	/* Prevent runtime stats get of uninitialized heap which causes unresponsiveness. */
+	if (!nrf_modem_is_initialized()) {
+		return -ESHUTDOWN;
+	}
+
 	if (!stats) {
 		return -EFAULT;
 	}


### PR DESCRIPTION
If `nrf_modem_lib_diag_stats_get` is called when
Modem library is not initialized, the
`sys_heap_runtime_stats_get` function will become
unresponsive because the Modem library heaps
are not initialized.