### PR TITLE
lib: nrf_modem: init once on dfu apply

### DIFF
--- a/applications/asset_tracker_v2/src/main.c
+++ b/applications/asset_tracker_v2/src/main.c
@@ -183,19 +183,19 @@ static void on_modem_lib_dfu(int dfu_res, void *ctx)
 		/* Fallthrough */
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
-		LOG_ERR("MODEM UPDATE ERROR %d. Running old firmware", dfu_res);
+		LOG_ERR("MODEM UPDATE ERROR 0x%x. Running old firmware", dfu_res);
 		break;
 	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
 	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
-		LOG_ERR("MODEM UPDATE FATAL ERROR %d. Modem failure", dfu_res);
+		LOG_ERR("MODEM UPDATE FATAL ERROR 0x%x. Modem failure", dfu_res);
 		break;
 	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
-		LOG_ERR("MODEM UPDATE CANCELLED %d.", dfu_res);
+		LOG_ERR("MODEM UPDATE CANCELLED 0x%x.", dfu_res);
 		LOG_ERR("Please reboot once you have sufficient power for the DFU");
 		break;
 	default:
 		/* Unknown DFU result code */
-		LOG_ERR("nRF modem DFU failed, error: %d", dfu_res);
+		LOG_ERR("nRF modem DFU failed, error: 0x%x", dfu_res);
 		break;
 	}
 }
@@ -207,17 +207,15 @@ NRF_MODEM_LIB_ON_DFU_RES(main_dfu_hook, on_modem_lib_dfu, NULL);
  */
 static void modem_init(void)
 {
-	int ret = nrf_modem_lib_init();
+	int ret;
 
-	/* Handle return values */
-	switch (ret) {
-	case 0:
+	ret = nrf_modem_lib_init();
+	if (ret == 0) {
 		LOG_DBG("nRF Modem Library initialized successfully");
 		return;
-	default:
-		LOG_ERR("nRF modem lib initialization failed, error: %d", ret);
-		break;
 	}
+
+	LOG_ERR("nRF modem lib initialization failed, error: %d", ret);
 
 #if defined(CONFIG_NRF_CLOUD_FOTA)
 	/* Ignore return value, rebooting below */

--- a/applications/serial_lte_modem/src/main.c
+++ b/applications/serial_lte_modem/src/main.c
@@ -257,26 +257,26 @@ static void nrf_modem_on_dfu_res(int dfu_res, void *ctx)
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
-		LOG_ERR("MODEM UPDATE ERROR %d. Running old firmware", dfu_res);
+		LOG_ERR("MODEM UPDATE ERROR 0x%x. Running old firmware", dfu_res);
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = dfu_res;
 		break;
 	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
 	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
-		LOG_ERR("MODEM UPDATE FATAL ERROR %d", dfu_res);
+		LOG_ERR("MODEM UPDATE FATAL ERROR 0x%x", dfu_res);
 		LOG_ERR("Please program full modem firmware with the bootloader or external tools");
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = dfu_res;
 		break;
 	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
-		LOG_ERR("MODEM UPDATE CANCELLED %d.", dfu_res);
+		LOG_ERR("MODEM UPDATE CANCELLED 0x%x.", dfu_res);
 		LOG_ERR("Please reboot once you have sufficient power for the DFU");
 		fota_stage = FOTA_STAGE_ACTIVATE;
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = dfu_res;
 		break;
 	default:
-		LOG_ERR("Unknown DFU result: %d", dfu_res);
+		LOG_ERR("Unknown DFU result: 0x%x", dfu_res);
 		fota_status = FOTA_STATUS_ERROR;
 		fota_info = dfu_res;
 	}

--- a/applications/serial_lte_modem/src/slm_at_commands.c
+++ b/applications/serial_lte_modem/src/slm_at_commands.c
@@ -250,16 +250,17 @@ static int handle_at_modemreset(enum at_cmd_type type)
 		++step;
 
 		ret = nrf_modem_lib_init();
+
+		/* nrf_modem_dfu_res() is called in nrf_modem_lib_init with the DFU result.  */
+		if ((fota_stage != FOTA_STAGE_INIT &&
+		     fota_type == DFU_TARGET_IMAGE_TYPE_MODEM_DELTA)) {
+			slm_fota_post_process();
+		}
+
 		if (ret < 0) {
 			break;
 		}
 		++step;
-
-		if (ret > 0 || (fota_stage != FOTA_STAGE_INIT
-					&& fota_type == DFU_TARGET_IMAGE_TYPE_MODEM_DELTA)) {
-			slm_finish_modem_fota(ret);
-			slm_fota_post_process();
-		}
 
 		/* Success. */
 		rsp_send("\r\n#XMODEMRESET: 0\r\n");

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -376,7 +376,6 @@ void slm_fota_post_process(void)
 void slm_finish_modem_fota(int modem_lib_init_ret)
 {
 	if (handle_nrf_modem_lib_init_ret(modem_lib_init_ret)) {
-		char buf[40];
 
 		LOG_INF("Re-initializing the modem due to"
 				" ongoing modem firmware update.");
@@ -387,15 +386,5 @@ void slm_finish_modem_fota(int modem_lib_init_ret)
 		 */
 		modem_lib_init_ret = nrf_modem_lib_init();
 		handle_nrf_modem_lib_init_ret(modem_lib_init_ret);
-
-		nrf_modem_at_cmd(buf, sizeof(buf), "%s", "AT%SHORTSWVER");
-		if (strstr(buf, "1.3.4") || strstr(buf, "1.3.5")) {
-			/* Those versions suffer from a bug that provokes UICC failure (+CEREG: 90)
-			 * after the update, preventing the modem from registering to the network.
-			 */
-			LOG_INF("Applying the workaround to a modem firmware update issue...");
-			nrf_modem_lib_shutdown();
-			nrf_modem_lib_init();
-		}
 	}
 }

--- a/applications/serial_lte_modem/src/slm_at_fota.c
+++ b/applications/serial_lte_modem/src/slm_at_fota.c
@@ -372,19 +372,3 @@ void slm_fota_post_process(void)
 		slm_settings_fota_save();
 	}
 }
-
-void slm_finish_modem_fota(int modem_lib_init_ret)
-{
-	if (handle_nrf_modem_lib_init_ret(modem_lib_init_ret)) {
-
-		LOG_INF("Re-initializing the modem due to"
-				" ongoing modem firmware update.");
-
-		/* The second init needs to be done regardless of the return value.
-		 * Refer to the below link for more information on the procedure.
-		 * https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrfxlib/nrf_modem/doc/delta_dfu.html#reinitializing-the-modem-to-run-the-new-firmware
-		 */
-		modem_lib_init_ret = nrf_modem_lib_init();
-		handle_nrf_modem_lib_init_ret(modem_lib_init_ret);
-	}
-}

--- a/applications/serial_lte_modem/src/slm_at_fota.h
+++ b/applications/serial_lte_modem/src/slm_at_fota.h
@@ -57,21 +57,5 @@ int slm_at_fota_uninit(void);
  */
 void slm_fota_post_process(void);
 
-/**
- * @brief Finishes the modem firmware update.
- *
- * This is to be called after the application or modem
- * has been rebooted and a modem firmware update is ongoing.
- */
-void slm_finish_modem_fota(int modem_lib_init_ret);
-
-/**
- * @brief Handles @ref nrf_modem_lib_init() return values
- * relating to modem firmware update.
- *
- * @return Whether the modem must be re-initialized.
- */
-bool handle_nrf_modem_lib_init_ret(int modem_lib_init_ret);
-
 /** @} */
 #endif /* SLM_AT_FOTA_ */

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -38,7 +38,20 @@ extern "C" {
  * Use @ref nrf_modem_lib_init() to initialize in normal mode and
  * @ref nrf_modem_lib_bootloader_init() to initialize the Modem library in bootloader mode.
  *
- * @return int Zero on success, non-zero otherwise.
+ * @retval Zero on success.
+ *
+ * @retval -NRF_EPERM The Modem library is already initialized.
+ * @retval -NRF_EFAULT @c init_params is @c NULL.
+ * @retval -NRF_ENOLCK Not enough semaphores.
+ * @retval -NRF_ENOMEM Not enough shared memory.
+ * @retval -NRF_EINVAL Control region size is incorrect or missing handlers in @c init_params.
+ * @retval -NRF_ENOTSUPP RPC version mismatch.
+ * @retval -NRF_ETIMEDOUT Operation timed out.
+ * @retval -NRF_ACCESS Modem firmware authentication failure.
+ * @retval -NRF_EAGAIN Modem device firmware upgrade failure.
+ *		       DFU is scheduled at next initialization.
+ * @retval -NRF_EIO Modem device firmware upgrade failure.
+ *		    Reprogramming the modem firmware is necessary to recover.
  */
 int nrf_modem_lib_init(void);
 
@@ -53,7 +66,17 @@ int nrf_modem_lib_init(void);
  * Use @ref nrf_modem_lib_init() to initialize in normal mode and
  * @ref nrf_modem_lib_bootloader_init() to initialize the Modem library in bootloader mode.
  *
- * @return int Zero on success, non-zero otherwise.
+ * @retval Zero on success.
+ *
+ * @retval -NRF_EPERM The Modem library is already initialized.
+ * @retval -NRF_EFAULT @c init_params is @c NULL.
+ * @retval -NRF_ENOLCK Not enough semaphores.
+ * @retval -NRF_ENOMEM Not enough shared memory.
+ * @retval -NRF_EINVAL Missing handler in @c init_params.
+ * @retval -NRF_EACCES Bad root digest.
+ * @retval -NRF_ETIMEDOUT Operation timed out.
+ * @retval -NRF_EIO Bootloader fault.
+ * @retval -NRF_ENOSYS Operation not available.
  */
 int nrf_modem_lib_bootloader_init(void);
 

--- a/include/modem/nrf_modem_lib.h
+++ b/include/modem/nrf_modem_lib.h
@@ -38,8 +38,7 @@ extern "C" {
  * Use @ref nrf_modem_lib_init() to initialize in normal mode and
  * @ref nrf_modem_lib_bootloader_init() to initialize the Modem library in bootloader mode.
  *
- * @return int Zero on success, a positive value @em nrf_modem_dfu when executing
- *         Modem firmware updates, and negative errno on other failures.
+ * @return int Zero on success, non-zero otherwise.
  */
 int nrf_modem_lib_init(void);
 
@@ -68,6 +67,20 @@ int nrf_modem_lib_bootloader_init(void);
 int nrf_modem_lib_shutdown(void);
 
 /**
+ * @brief Modem library dfu callback struct.
+ */
+struct nrf_modem_lib_dfu_cb {
+	/**
+	 * @brief Callback function.
+	 * @param dfu_res The return value of nrf_modem_init()
+	 * @param ctx User-defined context
+	 */
+	void (*callback)(int dfu_res, void *ctx);
+	/** User defined context */
+	void *context;
+};
+
+/**
  * @brief Modem library initialization callback struct.
  */
 struct nrf_modem_lib_init_cb {
@@ -93,6 +106,25 @@ struct nrf_modem_lib_shutdown_cb {
 	/** User defined context */
 	void *context;
 };
+
+/**
+ * @brief Define a callback for DFU result @ref nrf_modem_lib_init calls.
+ *
+ * The callback function @p _callback is invoked after the library has been initialized.
+ *
+ * @note The @c NRF_MODEM_LIB_ON_DFU_RES callback can be used to subscribe to the result of a modem
+ * DFU operation.
+ *
+ * @param name Callback name
+ * @param _callback Callback function name
+ * @param _context User-defined context for the callback
+ */
+#define NRF_MODEM_LIB_ON_DFU_RES(name, _callback, _context)                                        \
+	static void _callback(int dfu_res, void *ctx);                                             \
+	STRUCT_SECTION_ITERABLE(nrf_modem_lib_dfu_cb, nrf_modem_dfu_hook_##name) = {               \
+		.callback = _callback,                                                             \
+		.context = _context,                                                               \
+	};
 
 /**
  * @brief Define a callback for @ref nrf_modem_lib_init calls.

--- a/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
@@ -14,6 +14,9 @@
 #define LWM2M_CARRIER_THREAD_STACK_SIZE 4096
 #define LWM2M_CARRIER_THREAD_PRIORITY K_LOWEST_APPLICATION_THREAD_PRIO
 
+int nrf_modem_dfu_result;
+
+NRF_MODEM_LIB_ON_DFU_RES(lwm2m_carrier_dfu_hook, on_modem_lib_dfu, NULL);
 NRF_MODEM_LIB_ON_INIT(lwm2m_carrier_init_hook, on_modem_lib_init, NULL);
 NRF_MODEM_LIB_ON_SHUTDOWN(lwm2m_carrier_shutdown_hook, on_modem_lib_shutdown, NULL);
 
@@ -92,41 +95,50 @@ __weak int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 }
 #endif
 
+static void on_modem_lib_dfu(int32_t dfu_res, void *ctx)
+{
+	switch (dfu_res) {
+	case NRF_MODEM_DFU_RESULT_OK:
+		printk("Modem firmware update successful.\n");
+		printk("Modem is running the new firmware.\n");
+		nrf_modem_dfu_result = LWM2M_CARRIER_MODEM_INIT_UPDATED;
+		break;
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
+		printk("Modem firmware update failed.\n");
+		printk("Modem is running non-updated firmware.\n");
+		nrf_modem_dfu_result = LWM2M_CARRIER_MODEM_INIT_UPDATE_FAILED;
+		break;
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
+		printk("Modem firmware update failed.\n");
+		printk("Fatal error.\n");
+		nrf_modem_dfu_result = LWM2M_CARRIER_MODEM_INIT_UPDATE_FAILED;
+		break;
+	}
+}
+
 static void on_modem_lib_init(int ret, void *ctx)
 {
 	ARG_UNUSED(ctx);
 
 	int result;
 
-	switch (ret) {
-	case 0:
-		result = LWM2M_CARRIER_MODEM_INIT_SUCCESS;
-		break;
-	case NRF_MODEM_DFU_RESULT_OK:
-		printk("Modem firmware update successful.\n");
-		printk("Modem will run the new firmware after next initialization.\n");
-		result = LWM2M_CARRIER_MODEM_INIT_UPDATED;
-		break;
-	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
-	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
-		printk("Modem firmware update failed.\n");
-		printk("Modem will run non-updated firmware on next initialization.\n");
-		result = LWM2M_CARRIER_MODEM_INIT_UPDATE_FAILED;
-		break;
-	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
-		printk("Modem firmware update failed.\n");
-		printk("Fatal error.\n");
-		result = LWM2M_CARRIER_MODEM_INIT_UPDATE_FAILED;
-		break;
-	case -NRF_EPERM:
+	if (nrf_modem_dfu_result) {
+		result = nrf_modem_dfu_result;
+	} else if (ret == -NRF_EPERM) {
 		printk("Modem already initialized\n");
 		return;
-	default:
+	} else if (ret == 0) {
+		result = LWM2M_CARRIER_MODEM_INIT_SUCCESS;
+	} else {
 		printk("Could not initialize modem library.\n");
 		printk("Fatal error.\n");
 		result = -EIO;
 	}
+
+	/* Reset for a normal init without DFU. */
+	nrf_modem_dfu_result = 0;
 
 	lwm2m_carrier_on_modem_init(result);
 }

--- a/lib/lte_link_control/lte_lc_modem_hooks.c
+++ b/lib/lte_link_control/lte_lc_modem_hooks.c
@@ -17,10 +17,6 @@ NRF_MODEM_LIB_ON_SHUTDOWN(lte_lc_shutdown_hook, on_modem_shutdown, NULL);
 static void on_modem_init(int err, void *ctx)
 {
 	if (err) {
-		if (err == NRF_MODEM_DFU_RESULT_OK) {
-			LOG_DBG("Modem DFU, lte_lc not initialized");
-			return;
-		}
 		LOG_ERR("Modem library init error: %d, lte_lc not initialized", err);
 		return;
 	}

--- a/lib/nrf_modem_lib/lte_connectivity/lte_connectivity.c
+++ b/lib/nrf_modem_lib/lte_connectivity/lte_connectivity.c
@@ -212,48 +212,7 @@ static int modem_init(void)
 {
 	LOG_DBG("Initializing nRF Modem Library");
 
-	int ret = nrf_modem_lib_init();
-
-	/* Handle return values related to modem DFU. */
-	switch (ret) {
-	case 0:
-		/* Initialization successful, no action required. */
-		LOG_DBG("nRF Modem Library initialized successfully");
-		return 0;
-	case NRF_MODEM_DFU_RESULT_OK:
-		LOG_DBG("Modem DFU successful. The modem will run the updated "
-			"firmware after reinitialization.");
-		break;
-	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
-	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
-		LOG_ERR("Modem DFU error: %d. The modem will automatically run the previous "
-			"(non-updated) firmware after reinitialization.",
-			ret);
-		break;
-	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
-		LOG_ERR("Modem DFU not executed due to low voltage, error: %d. "
-			"The modem will retry the update on reinitialization.",
-			ret);
-		break;
-	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
-		/* Fall through */
-	default:
-		LOG_ERR("The modem encountered a fatal error during DFU: %d", ret);
-		return ret;
-	}
-
-	LOG_DBG("Reinitializing nRF Modem Library");
-
-	ret = nrf_modem_lib_init();
-	if (ret) {
-		LOG_ERR("Reinitialization of nRF Modem library failed, retval: %d", ret);
-		return ret;
-	}
-
-	LOG_DBG("nRF Modem Library reinitialized");
-
-	return 0;
+	return nrf_modem_lib_init();
 }
 
 static void on_pdn_activated(void)

--- a/lib/nrf_modem_lib/lte_connectivity/lte_connectivity.h
+++ b/lib/nrf_modem_lib/lte_connectivity/lte_connectivity.h
@@ -66,8 +66,6 @@ void lte_connectivity_init(struct conn_mgr_conn_binding * const if_conn);
  *	     for more information.
  *
  *  @returns 0 on success, nonzero value on failure.
- *	     If a positive value is returned, modem reinitialization failed. (DFU related)
- *	     DFU related error codes are listed in nrf_modem.h prefixed NRF_MODEM_DFU_RESULT.
  */
 int lte_connectivity_enable(void);
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -114,7 +114,7 @@ static void log_fw_version_uuid(void)
 
 static void nrf_modem_lib_dfu_handler(uint32_t dfu_res)
 {
-	LOG_DBG("Modem library dfu res %d", dfu_res);
+	LOG_DBG("Modem library update result %d", dfu_res);
 	STRUCT_SECTION_FOREACH(nrf_modem_lib_dfu_cb, e) {
 		LOG_DBG("Modem dfu callback: %p", e->callback);
 		e->callback(dfu_res, e->context);

--- a/lib/nrf_modem_lib/nrf_modem_lib.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib.c
@@ -36,6 +36,8 @@ BUILD_ASSERT(IPC_IRQn == NRF_MODEM_IPC_IRQ, "NRF_MODEM_IPC_IRQ mismatch");
  */
 #define NRF_MODEM_LIB_SHMEM_TX_HEAP_OVERHEAD_SIZE 128
 
+static void nrf_modem_lib_dfu_handler(uint32_t dfu_res);
+
 static const struct nrf_modem_init_params init_params = {
 	.ipc_irq_prio = CONFIG_NRF_MODEM_LIB_IPC_IRQ_PRIO,
 	.shmem.ctrl = {
@@ -57,7 +59,8 @@ static const struct nrf_modem_init_params init_params = {
 		.size = CONFIG_NRF_MODEM_LIB_SHMEM_TRACE_SIZE,
 	},
 #endif
-	.fault_handler = nrf_modem_fault_handler
+	.fault_handler = nrf_modem_fault_handler,
+	.dfu_handler = nrf_modem_lib_dfu_handler,
 };
 
 static const struct nrf_modem_bootloader_init_params bootloader_init_params = {
@@ -106,6 +109,15 @@ static void log_fw_version_uuid(void)
 	} else {
 		LOG_ERR("Unable to obtain modem FW UUID (ERR: %d, ERR TYPE: %d)\n",
 			nrf_modem_at_err(err), nrf_modem_at_err_type(err));
+	}
+}
+
+static void nrf_modem_lib_dfu_handler(uint32_t dfu_res)
+{
+	LOG_DBG("Modem library dfu res %d", dfu_res);
+	STRUCT_SECTION_FOREACH(nrf_modem_lib_dfu_cb, e) {
+		LOG_DBG("Modem dfu callback: %p", e->callback);
+		e->callback(dfu_res, e->context);
 	}
 }
 

--- a/lib/nrf_modem_lib/nrf_modem_lib.ld
+++ b/lib/nrf_modem_lib/nrf_modem_lib.ld
@@ -1,4 +1,7 @@
 . = ALIGN(4);
+_nrf_modem_lib_dfu_cb_list_start = .;
+KEEP(*(SORT_BY_NAME("._nrf_modem_lib_dfu_cb.*")));
+_nrf_modem_lib_dfu_cb_list_end = .;
 _nrf_modem_lib_init_cb_list_start = .;
 KEEP(*(SORT_BY_NAME("._nrf_modem_lib_init_cb.*")));
 _nrf_modem_lib_init_cb_list_end = .;

--- a/lib/nrf_modem_lib/nrf_modem_lib_trace.c
+++ b/lib/nrf_modem_lib/nrf_modem_lib_trace.c
@@ -331,7 +331,7 @@ static int trace_init(void)
 
 static void trace_init_callback(int err, void *ctx)
 {
-	if (err) {
+	if (err != 0) {
 		return;
 	}
 

--- a/samples/cellular/azure_fota/src/main.c
+++ b/samples/cellular/azure_fota/src/main.c
@@ -190,25 +190,16 @@ static void modem_configure(void)
 	}
 }
 
-int main(void)
+static void on_modem_lib_dfu(int32_t dfu_res, void *ctx)
 {
-	int err;
-
-	LOG_INF("Azure FOTA sample started");
-	LOG_INF("This may take a while if a modem firmware update is pending");
-
-	err = nrf_modem_lib_init();
-
-	switch (err) {
+	switch (dfu_res) {
 	case NRF_MODEM_DFU_RESULT_OK:
-		LOG_INF("Modem firmware update successful!");
-		LOG_INF("Modem will run the new firmware after reboot");
-		k_thread_suspend(k_current_get());
+		LOG_DBG("nRF Modem firmware updated");
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		LOG_INF("Modem firmware update failed");
-		LOG_INF("Modem will run non-updated firmware on reboot.");
+		LOG_INF("Modem is running old firmware.");
 		break;
 	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
 	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
@@ -219,12 +210,25 @@ int main(void)
 		LOG_INF("Modem firmware update failed");
 		LOG_INF("Please reboot once you have sufficient power for the DFU.");
 		break;
-	case -1:
+	default:
+		break;
+	}
+}
+
+NRF_MODEM_LIB_ON_DFU_RES(main_dfu_hook, on_modem_lib_dfu, NULL);
+
+int main(void)
+{
+	int err;
+
+	LOG_INF("Azure FOTA sample started");
+	LOG_INF("This may take a while if a modem firmware update is pending");
+
+	err = nrf_modem_lib_init();
+	if (err) {
 		LOG_INF("Could not initialize modem library");
 		LOG_INF("Fatal error.");
 		return 0;
-	default:
-		break;
 	}
 
 	k_work_init_delayable(&reboot_work, reboot_work_fn);

--- a/samples/cellular/azure_fota/src/main.c
+++ b/samples/cellular/azure_fota/src/main.c
@@ -194,7 +194,7 @@ static void on_modem_lib_dfu(int32_t dfu_res, void *ctx)
 {
 	switch (dfu_res) {
 	case NRF_MODEM_DFU_RESULT_OK:
-		LOG_DBG("nRF Modem firmware updated");
+		LOG_DBG("Modem firmware updated");
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -81,7 +81,7 @@ static void on_modem_lib_dfu(int32_t dfu_res, void *ctx)
 {
 	switch (err) {
 	case NRF_MODEM_DFU_RESULT_OK:
-		LOG_DBG("nRF Modem firmware updated");
+		LOG_DBG("Modem firmware updated");
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:

--- a/samples/cellular/http_update/modem_delta_update/src/main.c
+++ b/samples/cellular/http_update/modem_delta_update/src/main.c
@@ -77,27 +77,16 @@ static int num_leds(void)
 	}
 }
 
-int main(void)
+static void on_modem_lib_dfu(int32_t dfu_res, void *ctx)
 {
-	int err;
-
-	printk("HTTP delta modem update sample started\n");
-
-	printk("Initializing modem library\n");
-
-	err = nrf_modem_lib_init();
 	switch (err) {
 	case NRF_MODEM_DFU_RESULT_OK:
-		printk("Modem firmware update successful!\n");
-		printk("Modem will run the new firmware after reboot\n");
-		printk("Press 'Reset' button or enter 'reset' to apply new firmware\n");
-		k_thread_suspend(k_current_get());
+		LOG_DBG("nRF Modem firmware updated");
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
 		printk("Modem firmware update failed\n");
-		printk("Modem will run non-updated firmware on reboot.\n");
-		printk("Press 'Reset' button or enter 'reset'\n");
+		printk("Modem is running the old firmware.\n");
 		break;
 	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
 	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
@@ -108,13 +97,27 @@ int main(void)
 		printk("Modem firmware update failed\n");
 		printk("Please reboot once you have sufficient power for the DFU.\n");
 		break;
-	case -1:
-		printk("Could not initialize momdem library.\n");
-		printk("Fatal error.\n");
-		return 0;
 	default:
 		break;
 	}
+}
+
+NRF_MODEM_LIB_ON_DFU_RES(main_dfu_hook, on_modem_lib_dfu, NULL);
+
+int main(void)
+{
+	int err;
+
+	printk("HTTP delta modem update sample started\n");
+
+	printk("Initializing modem library\n");
+
+	err = nrf_modem_lib_init();
+	if (err) {
+		printk("Could not initialize momdem library, err %d\n", err);
+		return 0;
+	}
+
 	printk("Initialized modem library\n");
 
 	err = fota_download_init(fota_dl_handler);

--- a/samples/cellular/modem_shell/src/fota/fota.c
+++ b/samples/cellular/modem_shell/src/fota/fota.c
@@ -16,6 +16,35 @@
 #include "link.h"
 #include "mosh_print.h"
 
+static void on_modem_lib_dfu(uint32_t dfu_res, void *ctx)
+{
+	switch (dfu_res) {
+	case NRF_MODEM_DFU_RESULT_OK:
+		LOG_DBG("nRF Modem firmware updated");
+		mosh_error("FOTA: Modem firmware update successful!");
+		break;
+	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
+	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
+		mosh_error("FOTA: Modem firmware update failed, err: 0x%08x", err);
+		mosh_error("FOTA: Modem is running previous firmware");
+		break;
+	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
+		mosh_error("FOTA: Fatal error, modem firmware update failed, err: 0x%08x", err);
+		__ASSERT(false, "Modem firmware update failed on fatal error");
+	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
+		mosh_error("FOTA: Modem firmware update cancelled due to low voltage");
+		mosh_error("FOTA: Please reboot once you have sufficient voltage for the DFU");
+		__ASSERT(false, "Modem firmware update cancelled due to low voltage");
+	default:
+		/* Modem library initialization failed. */
+		mosh_error("FOTA: Fatal error, could not initialize nrf_modem_lib, err: %d", err);
+		__ASSERT(false, "Could not initialize nrf_modem_lib");
+	}
+}
+
+NRF_MODEM_LIB_ON_DFU_RES(fota_dfu_hook, on_modem_lib_dfu, NULL);
+
 static void modem_update_apply(void)
 {
 	int err;
@@ -30,42 +59,9 @@ static void modem_update_apply(void)
 	}
 
 	err = nrf_modem_lib_init();
-	switch (err) {
-	case 0:
-		mosh_error("FOTA: Expected DFU result from modem library, "
-			   "but no DFU was triggered");
-		goto exit;
-	case NRF_MODEM_DFU_RESULT_OK:
-		mosh_print("FOTA: Modem firmware update successful!");
-		goto restart_modem;
-	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
-	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
-		mosh_error("FOTA: Modem firmware update failed, err: 0x%08x", err);
-		goto restart_modem;
-	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
-	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
-		mosh_error("FOTA: Fatal error, modem firmware update failed, err: 0x%08x", err);
-		__ASSERT(false, "Modem firmware update failed on fatal error");
-	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
-		mosh_error("FOTA: Modem firmware update cancelled due to low voltage");
-		mosh_error("FOTA: Please reboot once you have sufficient voltage for the DFU");
-		__ASSERT(false, "Modem firmware update cancelled due to low voltage");
-	default:
-		/* Modem library initialization failed. */
-		mosh_error("FOTA: Fatal error, could not initialize nrf_modem_lib, err: %d", err);
-		__ASSERT(false, "Could not initialize nrf_modem_lib");
-	}
-
-restart_modem:
-	mosh_print("FOTA: Restarting modem...");
-
-	err = nrf_modem_lib_shutdown();
 	if (err) {
-		mosh_warn("FOTA: Failed to shut down modem, err: %d", err);
+		__ASSERT(false, "Modem initialization failed, err: %d", err);
 	}
-
-	err = nrf_modem_lib_init();
-	__ASSERT(!err, "FOTA: Failed to initialize modem, err: %d", err);
 
 exit:
 	link_func_mode_set(LTE_LC_FUNC_MODE_NORMAL, true);

--- a/samples/cellular/modem_shell/src/fota/fota.c
+++ b/samples/cellular/modem_shell/src/fota/fota.c
@@ -20,7 +20,7 @@ static void on_modem_lib_dfu(uint32_t dfu_res, void *ctx)
 {
 	switch (dfu_res) {
 	case NRF_MODEM_DFU_RESULT_OK:
-		LOG_DBG("nRF Modem firmware updated");
+		LOG_DBG("Modem firmware updated");
 		mosh_error("FOTA: Modem firmware update successful!");
 		break;
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:

--- a/samples/cellular/nrf_cloud_mqtt_multi_service/src/connection.c
+++ b/samples/cellular/nrf_cloud_mqtt_multi_service/src/connection.c
@@ -714,14 +714,11 @@ static int setup_modem(void)
 	if (ret < 0) {
 		LOG_ERR("Modem library initialization failed, error: %d", ret);
 		return ret;
-	} else if (ret == NRF_MODEM_DFU_RESULT_OK) {
-		LOG_DBG("Modem library initialized after "
-			"successful modem firmware update.");
 	} else if (ret > 0) {
 		LOG_ERR("Modem library initialized after "
 			"failed modem firmware update, error: %d", ret);
 	} else {
-		LOG_DBG("Modem library initialized.");
+		LOG_DBG("nRF Modem Library initialized successfully");
 	}
 
 	/* Register to be notified when the modem has figured out the current time. */

--- a/samples/cellular/nrf_provisioning/sample.yaml
+++ b/samples/cellular/nrf_provisioning/sample.yaml
@@ -1,7 +1,7 @@
 sample:
   name: nRF Device Provisioning
 tests:
-  sample.cellular.nrf_provisioning:
+  sample.nrf9160.nrf_provisioning:
     build_only: true
     integration_platforms:
       - nrf9161dk_nrf9161_ns

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_firmware.c
@@ -223,7 +223,7 @@ static void on_modem_lib_dfu(int32_t dfu_res, void *ctx)
 		dfu_result = RESULT_SUCCESS;
 		break;
 	default:
-		LOG_INF("MODEM UPDATE fail %d", ret);
+		LOG_INF("MODEM UPDATE fail 0x%x", ret);
 		dfu_result = RESULT_UPDATE_FAILED;
 		break;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fota_common.c
@@ -22,17 +22,15 @@
 #include <net/nrf_cloud.h>
 
 #if defined(CONFIG_NRF_MODEM_LIB)
-NRF_MODEM_LIB_ON_INIT(nrf_cloud_fota_common_init_hook,
-		      on_modem_lib_init, NULL);
+static int dfu_result;
 
-/* Initialized to value different than success (0) */
-static int modem_lib_init_result = -1;
-
-static void on_modem_lib_init(int ret, void *ctx)
+static void on_modem_lib_dfu(int dfu_res, void *ctx)
 {
-	modem_lib_init_result = ret;
+	dfu_result = dfu_res;
 }
-#endif
+
+NRF_MODEM_LIB_ON_DFU_RES(main_dfu_hook, on_modem_lib_dfu, NULL);
+#endif /* CONFIG_NRF_MODEM_LIB*/
 
 LOG_MODULE_REGISTER(nrf_cloud_fota_common, CONFIG_NRF_CLOUD_LOG_LEVEL);
 
@@ -191,25 +189,28 @@ static enum nrf_cloud_fota_validate_status app_fota_validate_get(void)
 static enum nrf_cloud_fota_validate_status modem_delta_fota_validate_get(void)
 {
 #if defined(CONFIG_NRF_MODEM_LIB)
-	switch (modem_lib_init_result) {
+	switch (dfu_result) {
 	case NRF_MODEM_DFU_RESULT_OK:
-		LOG_INF("Modem FOTA update confirmed");
+		LOG_INF()"nRF Modem firmware update succeeded");
 		return NRF_CLOUD_FOTA_VALIDATE_PASS;
-	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
 	case NRF_MODEM_DFU_RESULT_UUID_ERROR:
 	case NRF_MODEM_DFU_RESULT_AUTH_ERROR:
+		LOG_ERR("MODEM UPDATE ERROR 0x%x. Running old firmware", dfu_result);
+		return NRF_CLOUD_FOTA_VALIDATE_FAIL;
 	case NRF_MODEM_DFU_RESULT_HARDWARE_ERROR:
-		LOG_ERR("Modem FOTA error: %d", modem_lib_init_result);
+	case NRF_MODEM_DFU_RESULT_INTERNAL_ERROR:
+		LOG_ERR("MODEM UPDATE FATAL ERROR 0x%x. Modem failure", dfu_result);
 		return NRF_CLOUD_FOTA_VALIDATE_FAIL;
 	case NRF_MODEM_DFU_RESULT_VOLTAGE_LOW:
-		LOG_ERR("Modem FOTA cancelled: %d", modem_lib_init_result);
+		LOG_ERR("MODEM UPDATE CANCELLED 0x%x.", dfu_result);
 		LOG_ERR("Please reboot once you have sufficient power for the DFU");
 		return NRF_CLOUD_FOTA_VALIDATE_FAIL;
 	default:
-		LOG_INF("Modem FOTA result unknown: %d", modem_lib_init_result);
+		/* Unknown DFU result code */
+		LOG_WRN("nRF modem DFU result unknown: 0x%x", dfu_result);
 		break;
 	}
-#endif
+#endif /* CONFIG_NRF_MODEM_LIB*/
 
 	return NRF_CLOUD_FOTA_VALIDATE_UNKNOWN;
 }

--- a/tests/lib/nrf_modem_lib/lte_connectivity/src/lte_connectivity_test.c
+++ b/tests/lib/nrf_modem_lib/lte_connectivity/src/lte_connectivity_test.c
@@ -215,12 +215,11 @@ void test_enable_should_init_modem_and_link_controller(void)
 	TEST_ASSERT_EQUAL(0, net_if_up(net_if));
 }
 
-void test_enable_should_init_modem_twice_upon_successful_dfu_result(void)
+void test_enable_should_init_modem_upon_successful_dfu_result(void)
 {
 	struct net_if *net_if = net_if_get_default();
 
 	__cmock_nrf_modem_is_initialized_ExpectAndReturn(0);
-	__cmock_nrf_modem_lib_init_ExpectAndReturn(NRF_MODEM_DFU_RESULT_OK);
 	__cmock_nrf_modem_lib_init_ExpectAndReturn(0);
 	__cmock_lte_lc_init_ExpectAndReturn(0);
 
@@ -232,9 +231,9 @@ void test_enable_should_return_error_upon_dfu_error(void)
 	struct net_if *net_if = net_if_get_default();
 
 	__cmock_nrf_modem_is_initialized_ExpectAndReturn(0);
-	__cmock_nrf_modem_lib_init_ExpectAndReturn(NRF_MODEM_DFU_RESULT_HARDWARE_ERROR);
+	__cmock_nrf_modem_lib_init_ExpectAndReturn(-EIO);
 
-	TEST_ASSERT_EQUAL(NRF_MODEM_DFU_RESULT_HARDWARE_ERROR, net_if_up(net_if));
+	TEST_ASSERT_EQUAL(-EIO, net_if_up(net_if));
 }
 
 /* Verify lte_connectivity_disable() */

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -641,7 +641,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_update)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADED, "wrong result value");
 
-	lwm2m_firmware_emulate_modem_lib_init(-NRF_EAGAIN);
+	lwm2m_firmware_emulate_modem_lib_init(-NRF_EIO);
 	do_firmware_update(modem_instance);
 	result = get_modem_result();
 	state = get_app_state();

--- a/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
+++ b/tests/subsys/net/lib/lwm2m_fota_utils/src/firmware.c
@@ -641,7 +641,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_update)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADED, "wrong result value");
 
-	lwm2m_firmware_emulate_modem_lib_init(NRF_MODEM_DFU_RESULT_AUTH_ERROR);
+	lwm2m_firmware_emulate_modem_lib_init(-NRF_EAGAIN);
 	do_firmware_update(modem_instance);
 	result = get_modem_result();
 	state = get_app_state();
@@ -662,7 +662,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_update)
 	printf("State %d\r\n", state);
 	zassert_equal(state, STATE_DOWNLOADED, "wrong result value");
 
-	lwm2m_firmware_emulate_modem_lib_init(NRF_MODEM_DFU_RESULT_OK);
+	lwm2m_firmware_emulate_modem_lib_init(0);
 	do_firmware_update(modem_instance);
 	result = get_modem_result();
 	zassert_equal(boot_img_num, 0, "wrong img num");
@@ -787,7 +787,7 @@ ZTEST(lwm2m_client_utils_firmware, test_firmware_multinstace_download)
 	printf("Update %d\r\n", rc);
 	zassert_equal(rc, 0, "wrong result value");
 	/* Stub Linked write for update */
-	lwm2m_firmware_emulate_modem_lib_init(NRF_MODEM_DFU_RESULT_OK);
+	lwm2m_firmware_emulate_modem_lib_init(0);
 	k_sleep(K_SECONDS(6));
 	state = get_modem_state();
 	zassert_equal(state, STATE_IDLE, "wrong result value");

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       repo-path: sdk-nrfxlib
       path: nrfxlib
       remote: lemrey
-      revision: pull/25/head
+      revision: a14c7b3f142f1c3c358a5d381007e7e438ff0386
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m

--- a/west.yml
+++ b/west.yml
@@ -142,10 +142,9 @@ manifest:
       revision: v3.3.0-ncs1
     - name: nrfxlib
       repo-path: sdk-nrfxlib
-      remote: lemrey
       path: nrfxlib
       remote: lemrey
-      revision: df876dc04e3664c1b747527ac7b19cbd69a3ca4f
+      revision: pull/25/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
It is no longer necessary to call nrf_modem_init twice when applying modem firmware updates.