### PR TITLE
lib: pdn: remove dependency on LTE link control library

### DIFF
--- a/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_wrapper.rst
+++ b/doc/nrf/libraries/modem/nrf_modem_lib/nrf_modem_lib_wrapper.rst
@@ -22,8 +22,8 @@ When using the Modem library in |NCS|, the library must be initialized and shutd
 
 .. _mlil_callbacks:
 
-Callbacks
-*********
+Modem library callbacks
+***********************
 
 Modem initialization and shutdown
 =================================

--- a/doc/nrf/libraries/modem/pdn.rst
+++ b/doc/nrf/libraries/modem/pdn.rst
@@ -21,9 +21,8 @@ The library uses several AT commands, and it relies on the following two types o
 * Notifications for unsolicited reporting of error codes sent by the network (``+CNEC``) - Subscribed by using the ``AT+CNEC=16`` command.
   See the `AT+CNEC set command`_ section in the nRF9160 AT Commands Reference Guide or the same section in the `nRF91x1 AT Commands Reference Guide`_ depending on the SiP you are using.
 
-If the application uses the :ref:`lte_lc_readme` library to change the modem's functional mode, the PDN library automatically subscribes to the necessary AT notifications.
+The PDN library automatically subscribes to the necessary AT notifications using :ref:`mlil_callbacks`.
 This includes automatically resubscribing to the notifications upon functional mode changes.
-If the application does not use the :ref:`lte_lc_readme` library to change the modem's functional mode, the application must subscribe to the necessary AT notifications manually.
 
 .. note::
    The subscription to AT notifications is lost upon changing the modem functional mode to ``+CFUN=0``.

--- a/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
+++ b/doc/nrf/releases_and_maturity/releases/release-notes-changelog.rst
@@ -756,6 +756,7 @@ Modem libraries
    * Added the :c:func:`pdn_dynamic_params_get` function to retrieve dynamic parameters of an active PDN connection.
    * Fixed a potential issue where the library tries to free the PDN context twice, causing the application to crash.
    * Updated the library to add PDP auto configuration to the :c:enumerator:`LTE_LC_FUNC_MODE_POWER_OFF` event.
+   * Removed the dependency on the :ref:`lte_lc_readme` library.
 
 * :ref:`lib_at_host` library:
 

--- a/lib/pdn/Kconfig
+++ b/lib/pdn/Kconfig
@@ -29,7 +29,6 @@ config PDN_INIT_PRIORITY
 
 config PDN_DEFAULTS_OVERRIDE
 	bool "Override defaults for PDP context 0"
-	depends on LTE_LINK_CONTROL
 	help
 	  The defaults are overridden automatically as soon as the modem has been initialized.
 


### PR DESCRIPTION

Remove dependency on LTE LC library in the PDN library.

Depends on #128 