### PR TITLE
treewide: change signature for nrf_modem_at_notif_handler_set

### DIFF
--- a/lib/at_monitor/at_monitor.c
+++ b/lib/at_monitor/at_monitor.c
@@ -107,10 +107,7 @@ static int at_monitor_sys_init(void)
 {
 	int err;
 
-	err = nrf_modem_at_notif_handler_set(at_monitor_dispatch);
-	if (err) {
-		LOG_ERR("Failed to hook the dispatch function, err %d", err);
-	}
+	nrf_modem_at_notif_handler_set(at_monitor_dispatch);
 
 	return 0;
 }

--- a/tests/lib/location/src/location_test.c
+++ b/tests/lib/location/src/location_test.c
@@ -999,7 +999,7 @@ void test_location_cellular_periodic(void)
 /* This is needed because AT Monitor library is initialized in SYS_INIT. */
 static int location_test_sys_init(void)
 {
-	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
+	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgs();
 
 	return 0;
 }

--- a/tests/lib/lte_lc_api/src/lte_lc_api_test.c
+++ b/tests/lib/lte_lc_api/src/lte_lc_api_test.c
@@ -225,7 +225,7 @@ void tearDown(void)
 /* This is needed because AT Monitor library is initialized in SYS_INIT. */
 static int sys_init_helper(void)
 {
-	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
+	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgs();
 
 	return 0;
 }

--- a/tests/lib/modem_info/src/main.c
+++ b/tests/lib/modem_info/src/main.c
@@ -19,7 +19,7 @@
 
 DEFINE_FFF_GLOBALS;
 
-FAKE_VALUE_FUNC(int, nrf_modem_at_notif_handler_set, nrf_modem_at_notif_handler_t);
+FAKE_VOID_FUNC(nrf_modem_at_notif_handler_set, nrf_modem_at_notif_handler_t);
 FAKE_VALUE_FUNC(int, at_params_list_init, struct at_param_list *, size_t);
 FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_scanf, const char *, const char *, ...);
 

--- a/tests/lib/sms/src/sms_test.c
+++ b/tests/lib/sms/src/sms_test.c
@@ -1942,7 +1942,7 @@ void test_recv_loop(void)
 /* This is needed because AT Monitor library is initialized in SYS_INIT. */
 static int sms_test_sys_init(void)
 {
-	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgsAndReturn(0);
+	__cmock_nrf_modem_at_notif_handler_set_ExpectAnyArgs();
 
 	return 0;
 }

--- a/tests/subsys/net/lib/nrf_provisioning/include/nrf_modem_at.h
+++ b/tests/subsys/net/lib/nrf_provisioning/include/nrf_modem_at.h
@@ -86,10 +86,8 @@ struct nrf_modem_at_cmd_filter {
  *	 Take care to offload any processing as appropriate.
  *
  * @param callback The AT notification callback. Use @c NULL to unset handler.
- *
- * @retval 0 On success.
  */
-int nrf_modem_at_notif_handler_set(nrf_modem_at_notif_handler_t callback);
+void nrf_modem_at_notif_handler_set(nrf_modem_at_notif_handler_t callback);
 
 /**
  * @brief Send a formatted AT command to the modem.

--- a/west.yml
+++ b/west.yml
@@ -39,6 +39,8 @@ manifest:
       url-base: https://github.com/BabbleSim
     - name: bosch
       url-base: https://github.com/boschsensortec
+    - name: lemrey
+      url-base: https://github.com/lemrey
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -141,7 +143,8 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 6db09621d01fd246d21010adc6ac8bdcb2a0e16a
+      remote: lemrey
+      revision: pull/35/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
nrf_modem_at_notif_handler_set is changed to void return.